### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/326/93/85632693.geojson
+++ b/data/856/326/93/85632693.geojson
@@ -990,6 +990,10 @@
     },
     "wof:country":"MA",
     "wof:country_alpha3":"MAR",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"ce22c482532ff649ee02130006b5e155",
     "wof:hierarchy":[
         {
@@ -1008,7 +1012,7 @@
         "fra",
         "tzm"
     ],
-    "wof:lastmodified":1566600145,
+    "wof:lastmodified":1582316073,
     "wof:name":"Morocco",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/858/022/55/85802255.geojson
+++ b/data/858/022/55/85802255.geojson
@@ -91,6 +91,10 @@
         "wd:id":"Q2826513"
     },
     "wof:country":"MA",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7ac95154f352b2900f8595ddf80e1e75",
     "wof:hierarchy":[
         {
@@ -106,7 +110,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566600145,
+    "wof:lastmodified":1582316073,
     "wof:name":"Agdal",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/59/85802259.geojson
+++ b/data/858/022/59/85802259.geojson
@@ -90,6 +90,10 @@
         "wd:id":"Q1169817"
     },
     "wof:country":"MA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4cc71135ccce7bddca2c2b83b77eb40e",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566600145,
+    "wof:lastmodified":1582316073,
     "wof:name":"A\u00efn Chock",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/77/85802277.geojson
+++ b/data/858/022/77/85802277.geojson
@@ -73,6 +73,9 @@
         "qs:id":1168136
     },
     "wof:country":"MA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00bef35b6aa6afe0ac55bb7e84ead16a",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1534379378,
+    "wof:lastmodified":1582316073,
     "wof:name":"Dbagh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/81/85802281.geojson
+++ b/data/858/022/81/85802281.geojson
@@ -84,6 +84,10 @@
         "qs_pg:id":238648
     },
     "wof:country":"MA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3c5a8550651b9b182dd970f4f98f2860",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566600145,
+    "wof:lastmodified":1582316073,
     "wof:name":"Doum",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/85/85802285.geojson
+++ b/data/858/022/85/85802285.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":238652
     },
     "wof:country":"MA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2202fa43c5f21177fb34f95f9dae83be",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566600145,
+    "wof:lastmodified":1582316073,
     "wof:name":"Dradeb",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/89/85802289.geojson
+++ b/data/858/022/89/85802289.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1026463
     },
     "wof:country":"MA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"595e16c16d2dddf64ed2ac7fdacf6052",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566600145,
+    "wof:lastmodified":1582316073,
     "wof:name":"El Hank",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/93/85802293.geojson
+++ b/data/858/022/93/85802293.geojson
@@ -89,6 +89,10 @@
         "wk:page":"Oasis (Casablanca)"
     },
     "wof:country":"MA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cec050b58216fb12d37ac2f14edbafc1",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566600145,
+    "wof:lastmodified":1582316073,
     "wof:name":"L'Oasis",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/023/03/85802303.geojson
+++ b/data/858/023/03/85802303.geojson
@@ -114,6 +114,10 @@
         "qs_pg:id":1083615
     },
     "wof:country":"MA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6c78ae7571d9d99ac1fe9da8bbaf54d",
     "wof:hierarchy":[
         {
@@ -129,7 +133,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566600145,
+    "wof:lastmodified":1582316073,
     "wof:name":"Oc\u00e9an",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/416/873/890416873.geojson
+++ b/data/890/416/873/890416873.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051168,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b2c41c57fd9734c54caf7cf9071f468d",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":890416873,
-    "wof:lastmodified":1566602044,
+    "wof:lastmodified":1582316109,
     "wof:name":"Dcheira El Jihadia",
     "wof:parent_id":890429093,
     "wof:placetype":"localadmin",

--- a/data/890/417/081/890417081.geojson
+++ b/data/890/417/081/890417081.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051179,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3a3c9db5dde0665c769d470901523612",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":890417081,
-    "wof:lastmodified":1566602037,
+    "wof:lastmodified":1582316108,
     "wof:name":"Majjate",
     "wof:parent_id":1108784837,
     "wof:placetype":"localadmin",

--- a/data/890/417/173/890417173.geojson
+++ b/data/890/417/173/890417173.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051186,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3ce5998fbc3e1edcc402236f58518ef",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":890417173,
-    "wof:lastmodified":1566602035,
+    "wof:lastmodified":1582316108,
     "wof:name":"Ighil N Oumgoun",
     "wof:parent_id":1108784839,
     "wof:placetype":"localadmin",

--- a/data/890/417/189/890417189.geojson
+++ b/data/890/417/189/890417189.geojson
@@ -72,6 +72,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051187,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5900f62b7de00342f318aab4acc96259",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":890417189,
-    "wof:lastmodified":1566602035,
+    "wof:lastmodified":1582316108,
     "wof:name":"Sidi H Saine Ou Ali",
     "wof:parent_id":1108784841,
     "wof:placetype":"localadmin",

--- a/data/890/417/231/890417231.geojson
+++ b/data/890/417/231/890417231.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051189,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0029da1075e192479379a9d08ebf4c89",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":890417231,
-    "wof:lastmodified":1566602038,
+    "wof:lastmodified":1582316108,
     "wof:name":"Oulad Fares El Halla",
     "wof:parent_id":1108784833,
     "wof:placetype":"localadmin",

--- a/data/890/417/249/890417249.geojson
+++ b/data/890/417/249/890417249.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051191,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96cbe52ff8e3bb37ad3b5e07235eece1",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890417249,
-    "wof:lastmodified":1566602037,
+    "wof:lastmodified":1582316108,
     "wof:name":"Ait Sidi Daoud",
     "wof:parent_id":1108784801,
     "wof:placetype":"localadmin",

--- a/data/890/418/101/890418101.geojson
+++ b/data/890/418/101/890418101.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051234,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e4843e454bb32e84315ccaf60a2af9bb",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890418101,
-    "wof:lastmodified":1566602057,
+    "wof:lastmodified":1582316109,
     "wof:name":"Cercle de Taourirt",
     "wof:parent_id":1108784775,
     "wof:placetype":"localadmin",

--- a/data/890/418/103/890418103.geojson
+++ b/data/890/418/103/890418103.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051234,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d7e4d2a679b8eed93fb714e77e8170c",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":890418103,
-    "wof:lastmodified":1566602056,
+    "wof:lastmodified":1582316109,
     "wof:name":"Taounate",
     "wof:parent_id":85673893,
     "wof:placetype":"county",

--- a/data/890/418/107/890418107.geojson
+++ b/data/890/418/107/890418107.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051234,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cb02f4feae5318927676e8a9192136ca",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":890418107,
-    "wof:lastmodified":1566602056,
+    "wof:lastmodified":1582316109,
     "wof:name":"Tan-Tan",
     "wof:parent_id":85673947,
     "wof:placetype":"county",

--- a/data/890/420/341/890420341.geojson
+++ b/data/890/420/341/890420341.geojson
@@ -84,6 +84,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051333,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6081fbd1d42a9d474472d2173dd2e5ea",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":890420341,
-    "wof:lastmodified":1566602054,
+    "wof:lastmodified":1582316109,
     "wof:name":"Sidi Aissa Ben Ali",
     "wof:parent_id":1108784787,
     "wof:placetype":"localadmin",

--- a/data/890/421/483/890421483.geojson
+++ b/data/890/421/483/890421483.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051394,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2da693fe69957440d16a9503a299ef0b",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":890421483,
-    "wof:lastmodified":1566602030,
+    "wof:lastmodified":1582316108,
     "wof:name":"Tetouan",
     "wof:parent_id":85673883,
     "wof:placetype":"county",

--- a/data/890/422/513/890422513.geojson
+++ b/data/890/422/513/890422513.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051449,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"539ee09292960d3dc9a3c439af65e624",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890422513,
-    "wof:lastmodified":1566601992,
+    "wof:lastmodified":1582316106,
     "wof:name":"Larache",
     "wof:parent_id":85673883,
     "wof:placetype":"county",

--- a/data/890/422/519/890422519.geojson
+++ b/data/890/422/519/890422519.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051450,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b472e248da6596a0a0cbc8cbced2852",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":890422519,
-    "wof:lastmodified":1566601991,
+    "wof:lastmodified":1582316106,
     "wof:name":"Khouribga",
     "wof:parent_id":85673901,
     "wof:placetype":"county",

--- a/data/890/422/523/890422523.geojson
+++ b/data/890/422/523/890422523.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051450,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c0c8e9b805fceabf764ef8afd230bce",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":890422523,
-    "wof:lastmodified":1566601992,
+    "wof:lastmodified":1582316106,
     "wof:name":"Assa-Zag",
     "wof:parent_id":85673947,
     "wof:placetype":"county",

--- a/data/890/422/887/890422887.geojson
+++ b/data/890/422/887/890422887.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051470,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8ac980279993af1f1f50163f9a51cf71",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890422887,
-    "wof:lastmodified":1566601990,
+    "wof:lastmodified":1582316106,
     "wof:name":"Amalou Ighriben",
     "wof:parent_id":1108784791,
     "wof:placetype":"localadmin",

--- a/data/890/423/747/890423747.geojson
+++ b/data/890/423/747/890423747.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051511,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d0a5f2d85bcac039a1d416fed0e593ff",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890423747,
-    "wof:lastmodified":1566602006,
+    "wof:lastmodified":1582316106,
     "wof:name":"Hassi Berkane",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/423/863/890423863.geojson
+++ b/data/890/423/863/890423863.geojson
@@ -72,6 +72,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051518,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a0e24525e8c38923c8751d648bb1cc90",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":890423863,
-    "wof:lastmodified":1566602011,
+    "wof:lastmodified":1582316107,
     "wof:name":"Tizi N Isly",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/423/967/890423967.geojson
+++ b/data/890/423/967/890423967.geojson
@@ -84,6 +84,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051523,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55379af4609409e373e9fb0796264fd2",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":890423967,
-    "wof:lastmodified":1566602008,
+    "wof:lastmodified":1582316107,
     "wof:name":"Sidi Bou Othmane",
     "wof:parent_id":1108784803,
     "wof:placetype":"localadmin",

--- a/data/890/424/057/890424057.geojson
+++ b/data/890/424/057/890424057.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051526,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"17eb32488ff4183d726bcdb4c8f33f82",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":890424057,
-    "wof:lastmodified":1566602002,
+    "wof:lastmodified":1582316106,
     "wof:name":"Oulad Aamer Tizmari",
     "wof:parent_id":1108784803,
     "wof:placetype":"localadmin",

--- a/data/890/424/095/890424095.geojson
+++ b/data/890/424/095/890424095.geojson
@@ -75,6 +75,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051529,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"61bff05f3b0d0e84ec5b86dd9a9c6c00",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":890424095,
-    "wof:lastmodified":1566602002,
+    "wof:lastmodified":1582316106,
     "wof:name":"Sidi Boubker El Haj",
     "wof:parent_id":890427533,
     "wof:placetype":"localadmin",

--- a/data/890/424/145/890424145.geojson
+++ b/data/890/424/145/890424145.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051531,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"845d93c03a79ab07f185511fded4e5a2",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":890424145,
-    "wof:lastmodified":1566602000,
+    "wof:lastmodified":1582316106,
     "wof:name":"Nouaceur",
     "wof:parent_id":85673901,
     "wof:placetype":"county",

--- a/data/890/424/147/890424147.geojson
+++ b/data/890/424/147/890424147.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051531,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec3401724ab234fef1c134c340efa859",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":890424147,
-    "wof:lastmodified":1566602003,
+    "wof:lastmodified":1582316106,
     "wof:name":"Mohammedia",
     "wof:parent_id":85673901,
     "wof:placetype":"county",

--- a/data/890/424/149/890424149.geojson
+++ b/data/890/424/149/890424149.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fcc13261d9d713c953dbb5a694ec20b7",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":890424149,
-    "wof:lastmodified":1566602003,
+    "wof:lastmodified":1582316106,
     "wof:name":"Zagora",
     "wof:parent_id":85673929,
     "wof:placetype":"county",

--- a/data/890/424/151/890424151.geojson
+++ b/data/890/424/151/890424151.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051532,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f6cddabbb0f756e9477fbf04f9c9329e",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":890424151,
-    "wof:lastmodified":1566601998,
+    "wof:lastmodified":1582316106,
     "wof:name":"Mediouna",
     "wof:parent_id":85673905,
     "wof:placetype":"county",

--- a/data/890/427/533/890427533.geojson
+++ b/data/890/427/533/890427533.geojson
@@ -221,6 +221,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051701,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f945418449049f89f39b54e6e0452988",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":890427533,
-    "wof:lastmodified":1566602057,
+    "wof:lastmodified":1582316109,
     "wof:name":"Kenitra",
     "wof:parent_id":85673897,
     "wof:placetype":"county",

--- a/data/890/428/801/890428801.geojson
+++ b/data/890/428/801/890428801.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051773,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9eecd165fb72eac8e664ba10d4946ba8",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":890428801,
-    "wof:lastmodified":1566602031,
+    "wof:lastmodified":1582316108,
     "wof:name":"Tiznit",
     "wof:parent_id":85673929,
     "wof:placetype":"county",

--- a/data/890/429/091/890429091.geojson
+++ b/data/890/429/091/890429091.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051792,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9f2cf587fb86ec6cc1647a8e78e6e1a",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":890429091,
-    "wof:lastmodified":1566602041,
+    "wof:lastmodified":1582316108,
     "wof:name":"Sidi Kacem",
     "wof:parent_id":85673897,
     "wof:placetype":"county",

--- a/data/890/429/093/890429093.geojson
+++ b/data/890/429/093/890429093.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30ed5f45e7941a6fd13e8ecf79b8b534",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":890429093,
-    "wof:lastmodified":1566602041,
+    "wof:lastmodified":1582316109,
     "wof:name":"Inezgane-Ait Melloul",
     "wof:parent_id":85673929,
     "wof:placetype":"county",

--- a/data/890/429/095/890429095.geojson
+++ b/data/890/429/095/890429095.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bfbad3c0e9ffb42652bd4e440b7aeb0e",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890429095,
-    "wof:lastmodified":1566602041,
+    "wof:lastmodified":1582316109,
     "wof:name":"Ifrane",
     "wof:parent_id":85673915,
     "wof:placetype":"county",

--- a/data/890/429/097/890429097.geojson
+++ b/data/890/429/097/890429097.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"95f8c449a02e593cca004f88db731109",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":890429097,
-    "wof:lastmodified":1566602041,
+    "wof:lastmodified":1582316109,
     "wof:name":"Al Hoceima",
     "wof:parent_id":85673893,
     "wof:placetype":"county",

--- a/data/890/429/099/890429099.geojson
+++ b/data/890/429/099/890429099.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f82a33c5f91a565b0b3ac164e0dd7346",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":890429099,
-    "wof:lastmodified":1566602041,
+    "wof:lastmodified":1582316108,
     "wof:name":"Agadir Ida-Outanane",
     "wof:parent_id":85673929,
     "wof:placetype":"county",

--- a/data/890/429/101/890429101.geojson
+++ b/data/890/429/101/890429101.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469051793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a62adb31e49ada9a9f50c359fdc0713e",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":890429101,
-    "wof:lastmodified":1566602041,
+    "wof:lastmodified":1582316109,
     "wof:name":"Skhirate-Temara",
     "wof:parent_id":85673911,
     "wof:placetype":"county",

--- a/data/890/436/419/890436419.geojson
+++ b/data/890/436/419/890436419.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052111,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78c60f955ed91302ec62b1c608e9312c",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":890436419,
-    "wof:lastmodified":1566602021,
+    "wof:lastmodified":1582316107,
     "wof:name":"Boulemane",
     "wof:parent_id":85673887,
     "wof:placetype":"county",

--- a/data/890/436/421/890436421.geojson
+++ b/data/890/436/421/890436421.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052111,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a96c89fbea9c0e41df444d04493d5f7d",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":890436421,
-    "wof:lastmodified":1566602021,
+    "wof:lastmodified":1582316107,
     "wof:name":"Benslimane",
     "wof:parent_id":85673901,
     "wof:placetype":"county",

--- a/data/890/436/455/890436455.geojson
+++ b/data/890/436/455/890436455.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052112,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"14dba31f8d8da2bdbd71f4e6646eeb98",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":890436455,
-    "wof:lastmodified":1566602021,
+    "wof:lastmodified":1582316107,
     "wof:name":"Nzalat Laadam",
     "wof:parent_id":1108784803,
     "wof:placetype":"localadmin",

--- a/data/890/436/791/890436791.geojson
+++ b/data/890/436/791/890436791.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052126,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c1a9e4faa453cbd513019e3286d15f67",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":890436791,
-    "wof:lastmodified":1566602019,
+    "wof:lastmodified":1582316107,
     "wof:name":"Taza",
     "wof:parent_id":85673893,
     "wof:placetype":"county",

--- a/data/890/437/999/890437999.geojson
+++ b/data/890/437/999/890437999.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052175,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b2dce7eeb027b235b29735dc5f18a62",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":890437999,
-    "wof:lastmodified":1566602013,
+    "wof:lastmodified":1582316107,
     "wof:name":"Rabat",
     "wof:parent_id":85673911,
     "wof:placetype":"county",

--- a/data/890/439/153/890439153.geojson
+++ b/data/890/439/153/890439153.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052223,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fcc0c877807c09e6896f00ad27d82ed7",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890439153,
-    "wof:lastmodified":1566602012,
+    "wof:lastmodified":1582316107,
     "wof:name":"Taliouine Assaka",
     "wof:parent_id":1108784815,
     "wof:placetype":"localadmin",

--- a/data/890/440/519/890440519.geojson
+++ b/data/890/440/519/890440519.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052286,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ac3f1b33cfb2d43d7fb883aaffd0cb65",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":890440519,
-    "wof:lastmodified":1566601982,
+    "wof:lastmodified":1582316106,
     "wof:name":"Sidi El Abed",
     "wof:parent_id":890418103,
     "wof:placetype":"localadmin",

--- a/data/890/440/689/890440689.geojson
+++ b/data/890/440/689/890440689.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052293,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f6ec227b6f5ea448ac57dabfd9322a0d",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":890440689,
-    "wof:lastmodified":1566601981,
+    "wof:lastmodified":1582316105,
     "wof:name":"Oulad Aissa",
     "wof:parent_id":890445399,
     "wof:placetype":"localadmin",

--- a/data/890/440/707/890440707.geojson
+++ b/data/890/440/707/890440707.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052294,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3eed5fa0a91d4cc612a49cfdf3de57b",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":890440707,
-    "wof:lastmodified":1566601980,
+    "wof:lastmodified":1582316105,
     "wof:name":"Tabia",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/440/847/890440847.geojson
+++ b/data/890/440/847/890440847.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052299,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3670a80a7c7b737fd49bf99e9f96510b",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":890440847,
-    "wof:lastmodified":1566601986,
+    "wof:lastmodified":1582316106,
     "wof:name":"Chichaoua",
     "wof:parent_id":85673933,
     "wof:placetype":"county",

--- a/data/890/440/849/890440849.geojson
+++ b/data/890/440/849/890440849.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052299,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"424ec8ad5b8a0af2623d2c562e94e5bb",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":890440849,
-    "wof:lastmodified":1566601986,
+    "wof:lastmodified":1582316106,
     "wof:name":"Sefrou",
     "wof:parent_id":85673887,
     "wof:placetype":"county",

--- a/data/890/440/881/890440881.geojson
+++ b/data/890/440/881/890440881.geojson
@@ -69,6 +69,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052300,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5021b7370e7dde3b8c14c7b9db7bfa78",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":890440881,
-    "wof:lastmodified":1566601981,
+    "wof:lastmodified":1582316105,
     "wof:name":"Tazarine",
     "wof:parent_id":890424149,
     "wof:placetype":"localadmin",

--- a/data/890/441/193/890441193.geojson
+++ b/data/890/441/193/890441193.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052313,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2ba66e48e518ffc9cc704982b465af64",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":890441193,
-    "wof:lastmodified":1566601993,
+    "wof:lastmodified":1582316106,
     "wof:name":"Oulad Daoud Zkhanine",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/442/529/890442529.geojson
+++ b/data/890/442/529/890442529.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052366,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"877d69c0d2b0aaa8c1698493e2512518",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":890442529,
-    "wof:lastmodified":1566602057,
+    "wof:lastmodified":1582316109,
     "wof:name":"Fahs-Anjra",
     "wof:parent_id":85673883,
     "wof:placetype":"county",

--- a/data/890/442/533/890442533.geojson
+++ b/data/890/442/533/890442533.geojson
@@ -424,6 +424,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052366,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f0fa7d3c10ca57d4cad9b27a5ae00c09",
     "wof:hierarchy":[
         {
@@ -434,7 +437,7 @@
         }
     ],
     "wof:id":890442533,
-    "wof:lastmodified":1566602057,
+    "wof:lastmodified":1582316109,
     "wof:name":"Casablanca",
     "wof:parent_id":85673905,
     "wof:placetype":"county",

--- a/data/890/444/507/890444507.geojson
+++ b/data/890/444/507/890444507.geojson
@@ -587,6 +587,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052471,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"78d833efe0360e0dc2adb1103fe05783",
     "wof:hierarchy":[
         {
@@ -598,7 +601,7 @@
         }
     ],
     "wof:id":890444507,
-    "wof:lastmodified":1566602040,
+    "wof:lastmodified":1582316108,
     "wof:name":"Rabat",
     "wof:parent_id":890437999,
     "wof:placetype":"locality",

--- a/data/890/445/395/890445395.geojson
+++ b/data/890/445/395/890445395.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052508,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e54479e5b90b03637604a451682bf2ef",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890445395,
-    "wof:lastmodified":1566602060,
+    "wof:lastmodified":1582316109,
     "wof:name":"Taroudant",
     "wof:parent_id":85673929,
     "wof:placetype":"county",

--- a/data/890/445/397/890445397.geojson
+++ b/data/890/445/397/890445397.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052508,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b0127c50a88cd16bfd85c822a0f266b4",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":890445397,
-    "wof:lastmodified":1566602059,
+    "wof:lastmodified":1582316109,
     "wof:name":"Safi",
     "wof:parent_id":85673937,
     "wof:placetype":"county",

--- a/data/890/445/399/890445399.geojson
+++ b/data/890/445/399/890445399.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052508,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f63aa6382efec4f9e7065f652ead489",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":890445399,
-    "wof:lastmodified":1566602059,
+    "wof:lastmodified":1582316109,
     "wof:name":"El Jadida",
     "wof:parent_id":85673937,
     "wof:placetype":"county",

--- a/data/890/452/779/890452779.geojson
+++ b/data/890/452/779/890452779.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052829,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28604f96a07b20a5c32981ceae831afd",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":890452779,
-    "wof:lastmodified":1566602017,
+    "wof:lastmodified":1582316107,
     "wof:name":"Beni Mellal",
     "wof:parent_id":85673919,
     "wof:placetype":"county",

--- a/data/890/452/887/890452887.geojson
+++ b/data/890/452/887/890452887.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052833,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"562aa81cdaa015b109459d160f27d57d",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890452887,
-    "wof:lastmodified":1566602015,
+    "wof:lastmodified":1582316107,
     "wof:name":"Sidi Bouzid Arragrag",
     "wof:parent_id":890440847,
     "wof:placetype":"localadmin",

--- a/data/890/453/851/890453851.geojson
+++ b/data/890/453/851/890453851.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052875,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8aff5954cfdafde3666817ff91712088",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":890453851,
-    "wof:lastmodified":1566602028,
+    "wof:lastmodified":1582316108,
     "wof:name":"Tata",
     "wof:parent_id":85673947,
     "wof:placetype":"county",

--- a/data/890/453/883/890453883.geojson
+++ b/data/890/453/883/890453883.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052877,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c25fc3db667d561d975f5067d2f3c36",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":890453883,
-    "wof:lastmodified":1566602029,
+    "wof:lastmodified":1582316108,
     "wof:name":"Chefchaouen",
     "wof:parent_id":85673883,
     "wof:placetype":"county",

--- a/data/890/453/895/890453895.geojson
+++ b/data/890/453/895/890453895.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052877,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1b0ae563bd53c6107604de0bc7d0ac6",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":890453895,
-    "wof:lastmodified":1566602028,
+    "wof:lastmodified":1582316107,
     "wof:name":"Oujda-Angad",
     "wof:parent_id":85673923,
     "wof:placetype":"county",

--- a/data/890/453/897/890453897.geojson
+++ b/data/890/453/897/890453897.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052877,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"226a58cc5e59ca4f4cf287a68d3c1004",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":890453897,
-    "wof:lastmodified":1566602030,
+    "wof:lastmodified":1582316108,
     "wof:name":"Khemisset",
     "wof:parent_id":85673911,
     "wof:placetype":"county",

--- a/data/890/453/939/890453939.geojson
+++ b/data/890/453/939/890453939.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052878,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e2c97e7292b97ffbc60684f4b5debdb",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":890453939,
-    "wof:lastmodified":1566602028,
+    "wof:lastmodified":1582316107,
     "wof:name":"Essaouira",
     "wof:parent_id":85673933,
     "wof:placetype":"county",

--- a/data/890/454/333/890454333.geojson
+++ b/data/890/454/333/890454333.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a10b35d80ee77be2a9cc31922107a3f0",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":890454333,
-    "wof:lastmodified":1566602025,
+    "wof:lastmodified":1582316107,
     "wof:name":"Fes",
     "wof:parent_id":85673887,
     "wof:placetype":"county",

--- a/data/890/455/271/890455271.geojson
+++ b/data/890/455/271/890455271.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"MA",
     "wof:created":1469052941,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bbd5efc82239513a7a4c52d3cd187d5d",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":890455271,
-    "wof:lastmodified":1566602019,
+    "wof:lastmodified":1582316107,
     "wof:name":"Nador",
     "wof:parent_id":85673923,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.