### PR TITLE
Name updates

### DIFF
--- a/data/112/578/138/5/1125781385.geojson
+++ b/data/112/578/138/5/1125781385.geojson
@@ -31,8 +31,14 @@
     "name:ara_x_preferred":[
         "\u0641\u0627\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0627\u0633"
+    ],
     "name:aze_x_preferred":[
         "F\u0259s"
+    ],
+    "name:bak_x_preferred":[
+        "\u0424\u04d9\u0441"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0424\u0435\u0441"
@@ -109,6 +115,9 @@
     "name:grn_x_preferred":[
         "Fes"
     ],
+    "name:hau_x_preferred":[
+        "Fas"
+    ],
     "name:heb_x_preferred":[
         "\u05e4\u05e1"
     ],
@@ -172,6 +181,9 @@
     "name:lav_x_preferred":[
         "F\u0113sa"
     ],
+    "name:lim_x_preferred":[
+        "Fez"
+    ],
     "name:lit_x_preferred":[
         "Fesas"
     ],
@@ -210,6 +222,9 @@
     ],
     "name:nob_x_variant":[
         "Fez"
+    ],
+    "name:nqo_x_preferred":[
+        "\u07dd\u07cd\u07d6\u07ed"
     ],
     "name:oci_x_preferred":[
         "F\u00e8s"
@@ -264,6 +279,9 @@
     ],
     "name:tat_x_preferred":[
         "\u0424\u04d9\u0441"
+    ],
+    "name:tel_x_preferred":[
+        "\u0c2a\u0c47\u0c1c\u0c4d"
     ],
     "name:tgl_x_preferred":[
         "Fes"
@@ -321,8 +339,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673887,
-        890454333
+        890454333,
+        85673887
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -343,7 +361,7 @@
         }
     ],
     "wof:id":1125781385,
-    "wof:lastmodified":1566602094,
+    "wof:lastmodified":1587428374,
     "wof:name":"F\u00e8s",
     "wof:parent_id":890454333,
     "wof:placetype":"locality",

--- a/data/856/326/93/85632693.geojson
+++ b/data/856/326/93/85632693.geojson
@@ -88,6 +88,9 @@
     "name:bam_x_variant":[
         "Mar\u0254ku"
     ],
+    "name:ban_x_preferred":[
+        "Maroko"
+    ],
     "name:bar_x_preferred":[
         "Marokko"
     ],
@@ -167,10 +170,19 @@
     "name:crh_x_preferred":[
         "Ma\u011frip"
     ],
+    "name:csb_x_preferred":[
+        "Marok\u00f2"
+    ],
     "name:cym_x_preferred":[
         "Moroco"
     ],
     "name:dan_x_preferred":[
+        "Marokko"
+    ],
+    "name:deu_at_x_preferred":[
+        "Marokko"
+    ],
+    "name:deu_ch_x_preferred":[
         "Marokko"
     ],
     "name:deu_x_colloquial":[
@@ -203,6 +215,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03b1\u03c1\u03cc\u03ba\u03bf"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Morocco"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Morocco"
     ],
     "name:eng_x_preferred":[
         "Morocco"
@@ -273,6 +291,9 @@
     "name:gag_x_preferred":[
         "Marokko"
     ],
+    "name:gcr_x_preferred":[
+        "Mar\u00f2k"
+    ],
     "name:gla_x_preferred":[
         "Maroco"
     ],
@@ -308,6 +329,9 @@
     ],
     "name:hau_x_variant":[
         "Moroko"
+    ],
+    "name:haw_x_preferred":[
+        "Moloko"
     ],
     "name:hbs_x_preferred":[
         "Maroko"
@@ -450,6 +474,9 @@
     "name:lav_x_preferred":[
         "Maroka"
     ],
+    "name:lez_x_preferred":[
+        "\u041a\u0430\u0442\u0435\u0433\u043e\u0440\u0438\u044f:\u041c\u0430\u0440\u043e\u043a\u043a\u043e"
+    ],
     "name:lfn_x_preferred":[
         "Magrib"
     ],
@@ -509,6 +536,9 @@
     ],
     "name:mon_x_preferred":[
         "\u041c\u0430\u0440\u043e\u043a\u043a\u043e"
+    ],
+    "name:mri_x_preferred":[
+        "Marako"
     ],
     "name:mrj_x_preferred":[
         "\u041c\u0430\u0440\u043e\u043a\u043a\u043e"
@@ -615,6 +645,9 @@
     "name:pol_x_preferred":[
         "Maroko"
     ],
+    "name:por_br_x_preferred":[
+        "Marrocos"
+    ],
     "name:por_x_preferred":[
         "Marrocos"
     ],
@@ -630,6 +663,9 @@
     "name:ron_x_preferred":[
         "Maroc"
     ],
+    "name:rue_x_preferred":[
+        "\u041c\u0430\u0440\u043e\u043a\u043a\u043e"
+    ],
     "name:run_x_preferred":[
         "Maroke"
     ],
@@ -644,6 +680,9 @@
     ],
     "name:san_x_preferred":[
         "\u092e\u094b\u0930\u093e\u0915\u094b"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c62\u1c73\u1c68\u1c73\u1c60\u1c60\u1c73"
     ],
     "name:scn_x_preferred":[
         "Maroccu"
@@ -666,8 +705,14 @@
     "name:sme_x_preferred":[
         "Marokko"
     ],
+    "name:smo_x_preferred":[
+        "Morocco"
+    ],
     "name:sna_x_preferred":[
         "Morocco"
+    ],
+    "name:snd_x_preferred":[
+        "\u0645\u0631\u0627\u06aa\u0634"
     ],
     "name:som_x_preferred":[
         "Marooko"
@@ -690,6 +735,12 @@
     "name:srd_x_preferred":[
         "Marocco"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u041c\u0430\u0440\u043e\u043a\u043e"
+    ],
+    "name:srp_el_x_preferred":[
+        "Maroko"
+    ],
     "name:srp_x_preferred":[
         "\u041c\u0430\u0440\u043e\u043a\u043e"
     ],
@@ -710,6 +761,9 @@
     ],
     "name:szl_x_preferred":[
         "Maroko"
+    ],
+    "name:szy_x_preferred":[
+        "Morocco"
     ],
     "name:tam_x_preferred":[
         "\u0bae\u0bca\u0bb0\u0bcb\u0b95\u0bcd\u0b95\u0bcb"
@@ -845,8 +899,14 @@
     "name:zha_x_preferred":[
         "Morocco"
     ],
+    "name:zho_hk_x_preferred":[
+        "\u6469\u6d1b\u54e5"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Morocco"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u6469\u6d1b\u54e5"
     ],
     "name:zho_x_preferred":[
         "\u6469\u6d1b\u54e5"
@@ -1013,7 +1073,7 @@
         "fra",
         "tzm"
     ],
-    "wof:lastmodified":1583797384,
+    "wof:lastmodified":1587428373,
     "wof:name":"Morocco",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/890/434/661/890434661.geojson
+++ b/data/890/434/661/890434661.geojson
@@ -85,11 +85,23 @@
     "name:dan_x_preferred":[
         "Casablanca"
     ],
+    "name:deu_ch_x_preferred":[
+        "Casablanca"
+    ],
     "name:deu_x_preferred":[
         "Casablanca"
     ],
+    "name:diq_x_preferred":[
+        "Kazablanka"
+    ],
     "name:ell_x_preferred":[
         "\u039a\u03b1\u03b6\u03b1\u03bc\u03c0\u03bb\u03ac\u03bd\u03ba\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Casablanca"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Casablanca"
     ],
     "name:eng_x_historical":[
         "White House"
@@ -271,6 +283,9 @@
     "name:pol_x_preferred":[
         "Casablanca"
     ],
+    "name:por_br_x_preferred":[
+        "Casablanca"
+    ],
     "name:por_x_preferred":[
         "Casablanca"
     ],
@@ -285,6 +300,9 @@
     ],
     "name:rus_x_preferred":[
         "\u041a\u0430\u0441\u0430\u0431\u043b\u0430\u043d\u043a\u0430"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c60\u1c5f\u1c65\u1c5f\u1c75\u1c5e\u1c5f\u1c71\u1c60\u1c5f"
     ],
     "name:scn_x_preferred":[
         "Casablanca"
@@ -374,6 +392,12 @@
         "Casablanca"
     ],
     "name:yue_x_preferred":[
+        "\u5361\u85a9\u5e03\u862d\u5361"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5361\u85a9\u5e03\u862d\u5361"
+    ],
+    "name:zho_tw_x_preferred":[
         "\u5361\u85a9\u5e03\u862d\u5361"
     ],
     "name:zho_x_preferred":[
@@ -480,8 +504,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673905,
-        890442533
+        890442533,
+        85673905
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -503,7 +527,7 @@
         }
     ],
     "wof:id":890434661,
-    "wof:lastmodified":1566602061,
+    "wof:lastmodified":1587428373,
     "wof:name":"Casablanca",
     "wof:parent_id":890442533,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.