### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/170/487/421170487.geojson
+++ b/data/421/170/487/421170487.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0635\u0648\u064a\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Essaouira"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170487,
-    "wof:lastmodified":1566601977,
-    "wof:name":"\u0627\u0644\u0635\u0648\u064a\u0631\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Essaouira",
     "wof:parent_id":890453939,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/170/487/421170487.geojson
+++ b/data/421/170/487/421170487.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-9.7687615,31.5138,-9.7687615,31.5138",
+    "geom:bbox":"-9.768762,31.5138,-9.768762,31.5138",
     "geom:latitude":31.5138,
     "geom:longitude":-9.768762,
     "iso:country":"MA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673933,
-        890453939
+        890453939,
+        85673933
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"MA",
     "wof:created":1459008855,
-    "wof:geomhash":"765a7241c130e20950c78689c4c0aa18",
+    "wof:geomhash":"e63099f107d837365f0e4b1a96340140",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170487,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423088,
     "wof:name":"Essaouira",
     "wof:parent_id":890453939,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -9.7687615,
+    -9.768762,
     31.5138,
-    -9.7687615,
+    -9.768762,
     31.5138
 ],
-  "geometry": {"coordinates":[-9.7687615,31.5138],"type":"Point"}
+  "geometry": {"coordinates":[-9.768762,31.5138],"type":"Point"}
 }

--- a/data/421/170/491/421170491.geojson
+++ b/data/421/170/491/421170491.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673887,
-        890454333
+        890454333,
+        85673887
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170491,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423089,
     "wof:name":"Fes",
     "wof:parent_id":890454333,
     "wof:placetype":"locality",

--- a/data/421/170/491/421170491.geojson
+++ b/data/421/170/491/421170491.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0641\u0627\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Fes"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170491,
-    "wof:lastmodified":1566601976,
-    "wof:name":"\u0641\u0627\u0633",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Fes",
     "wof:parent_id":890454333,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/170/495/421170495.geojson
+++ b/data/421/170/495/421170495.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421170495,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423083,
     "wof:name":"Agadir",
     "wof:parent_id":85673929,
     "wof:placetype":"locality",

--- a/data/421/170/495/421170495.geojson
+++ b/data/421/170/495/421170495.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0643\u0627\u062f\u064a\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Agadir"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421170495,
-    "wof:lastmodified":1566601977,
-    "wof:name":"\u0627\u0643\u0627\u062f\u064a\u0631",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Agadir",
     "wof:parent_id":85673929,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/170/715/421170715.geojson
+++ b/data/421/170/715/421170715.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-8.00148,31.6293035,-8.00148,31.6293035",
+    "geom:bbox":"-8.00148,31.629303,-8.00148,31.629303",
     "geom:latitude":31.629303,
     "geom:longitude":-8.00148,
     "iso:country":"MA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673933,
-        1108784829
+        1108784829,
+        85673933
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"MA",
     "wof:created":1459008865,
-    "wof:geomhash":"f5f42b56bfdd490e11363ddac5c60260",
+    "wof:geomhash":"28c957b9290e0a930ffebfbe5a1785c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170715,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"Marrakesh",
     "wof:parent_id":1108784829,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     -8.00148,
-    31.6293035,
+    31.629303,
     -8.00148,
-    31.6293035
+    31.629303
 ],
-  "geometry": {"coordinates":[-8.00148,31.6293035],"type":"Point"}
+  "geometry": {"coordinates":[-8.00148,31.629303],"type":"Point"}
 }

--- a/data/421/170/715/421170715.geojson
+++ b/data/421/170/715/421170715.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0631\u0627\u0643\u0634"
+    ],
+    "name:eng_x_preferred":[
+        "Marrakesh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170715,
-    "wof:lastmodified":1566601977,
-    "wof:name":"\u0645\u0631\u0627\u0643\u0634",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Marrakesh",
     "wof:parent_id":1108784829,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/170/719/421170719.geojson
+++ b/data/421/170/719/421170719.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0636\u064a\u0642"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mediek"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170719,
-    "wof:lastmodified":1566601977,
-    "wof:name":"\u0627\u0644\u0645\u0636\u064a\u0642",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mediek",
     "wof:parent_id":1108784777,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/170/719/421170719.geojson
+++ b/data/421/170/719/421170719.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673883,
-        1108784777
+        1108784777,
+        85673883
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170719,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mediek",
     "wof:parent_id":1108784777,
     "wof:placetype":"locality",

--- a/data/421/176/751/421176751.geojson
+++ b/data/421/176/751/421176751.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u0627\u0648\u0646\u0627\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Taounat"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421176751,
-    "wof:lastmodified":1566601978,
-    "wof:name":"\u062a\u0627\u0648\u0646\u0627\u062a",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Taounat",
     "wof:parent_id":890418103,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/176/751/421176751.geojson
+++ b/data/421/176/751/421176751.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673893,
-        890418103
+        890418103,
+        85673893
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421176751,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Taounat",
     "wof:parent_id":890418103,
     "wof:placetype":"locality",

--- a/data/421/177/235/421177235.geojson
+++ b/data/421/177/235/421177235.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        890429099
+        890429099,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421177235,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tamri",
     "wof:parent_id":890429099,
     "wof:placetype":"locality",

--- a/data/421/177/235/421177235.geojson
+++ b/data/421/177/235/421177235.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u0627\u0645\u0631\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Tamri"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421177235,
-    "wof:lastmodified":1566601977,
-    "wof:name":"\u062a\u0627\u0645\u0631\u064a",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Tamri",
     "wof:parent_id":890429099,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/180/369/421180369.geojson
+++ b/data/421/180/369/421180369.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u0648\u0642 \u0627\u0644\u0627\u0631\u0628\u0639\u0627\u0621 \u0627\u0644\u063a\u0631\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Souk Al Arba'a West"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421180369,
-    "wof:lastmodified":1566601970,
-    "wof:name":"\u0633\u0648\u0642 \u0627\u0644\u0627\u0631\u0628\u0639\u0627\u0621 \u0627\u0644\u063a\u0631\u0628",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Souk Al Arba'a West",
     "wof:parent_id":890427533,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/180/369/421180369.geojson
+++ b/data/421/180/369/421180369.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-6.002655,34.6903955,-6.002655,34.6903955",
+    "geom:bbox":"-6.002655,34.690396,-6.002655,34.690396",
     "geom:latitude":34.690396,
     "geom:longitude":-6.002655,
     "iso:country":"MA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673897,
-        890427533
+        890427533,
+        85673897
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"MA",
     "wof:created":1459009253,
-    "wof:geomhash":"c217ac19dbbd24a5eb1eb5014722e236",
+    "wof:geomhash":"acb30a2de355c8d9964882a72baef0fe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421180369,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Souk Al Arba'a West",
     "wof:parent_id":890427533,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     -6.002655,
-    34.6903955,
+    34.690396,
     -6.002655,
-    34.6903955
+    34.690396
 ],
-  "geometry": {"coordinates":[-6.002655,34.6903955],"type":"Point"}
+  "geometry": {"coordinates":[-6.002655,34.690396],"type":"Point"}
 }

--- a/data/421/182/347/421182347.geojson
+++ b/data/421/182/347/421182347.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Casablanca"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182347,
-    "wof:lastmodified":1566601978,
-    "wof:name":"\u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627\u0621",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Casablanca",
     "wof:parent_id":890442533,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/182/347/421182347.geojson
+++ b/data/421/182/347/421182347.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-7.621765,33.6001075,-7.621765,33.6001075",
+    "geom:bbox":"-7.621765,33.600108,-7.621765,33.600108",
     "geom:latitude":33.600108,
     "geom:longitude":-7.621765,
     "iso:country":"MA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673905,
-        890442533
+        890442533,
+        85673905
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"MA",
     "wof:created":1459009327,
-    "wof:geomhash":"ca2fa72981eb064e959e41b7333418de",
+    "wof:geomhash":"5bc2f596adce6cc4d38d801c208e486b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421182347,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423088,
     "wof:name":"Casablanca",
     "wof:parent_id":890442533,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     -7.621765,
-    33.6001075,
+    33.600108,
     -7.621765,
-    33.6001075
+    33.600108
 ],
-  "geometry": {"coordinates":[-7.621765,33.6001075],"type":"Point"}
+  "geometry": {"coordinates":[-7.621765,33.600108],"type":"Point"}
 }

--- a/data/421/184/287/421184287.geojson
+++ b/data/421/184/287/421184287.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-9.561023,31.5331155,-9.561023,31.5331155",
+    "geom:bbox":"-9.561023,31.533116,-9.561023,31.533116",
     "geom:latitude":31.533116,
     "geom:longitude":-9.561023,
     "iso:country":"MA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673933,
-        890453939
+        890453939,
+        85673933
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"MA",
     "wof:created":1459009406,
-    "wof:geomhash":"f543b6684edab92e67affad171311b73",
+    "wof:geomhash":"6168fb10aeeabec3dc2eca67e15e9a5b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421184287,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423091,
     "wof:name":"Ounagha",
     "wof:parent_id":890453939,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     -9.561023,
-    31.5331155,
+    31.533116,
     -9.561023,
-    31.5331155
+    31.533116
 ],
-  "geometry": {"coordinates":[-9.561023,31.5331155],"type":"Point"}
+  "geometry": {"coordinates":[-9.561023,31.533116],"type":"Point"}
 }

--- a/data/421/184/287/421184287.geojson
+++ b/data/421/184/287/421184287.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0648\u0646\u0627\u063a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ounagha"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421184287,
-    "wof:lastmodified":1566601976,
-    "wof:name":"\u0627\u0648\u0646\u0627\u063a\u0629",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Ounagha",
     "wof:parent_id":890453939,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/184/659/421184659.geojson
+++ b/data/421/184/659/421184659.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        890445395
+        890445395,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421184659,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Argana",
     "wof:parent_id":890445395,
     "wof:placetype":"locality",

--- a/data/421/184/659/421184659.geojson
+++ b/data/421/184/659/421184659.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0631\u0643\u0627\u0646\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Argana"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421184659,
-    "wof:lastmodified":1566601976,
-    "wof:name":"\u0627\u0631\u0643\u0627\u0646\u0629",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Argana",
     "wof:parent_id":890445395,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/189/993/421189993.geojson
+++ b/data/421/189/993/421189993.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0638\u0647\u0631 \u0627\u0644\u0645\u0647\u0631\u0627\u0632"
+    ],
+    "name:eng_x_preferred":[
+        "Dhar Al Mehraz"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189993,
-    "wof:lastmodified":1566601971,
-    "wof:name":"\u0638\u0647\u0631 \u0627\u0644\u0645\u0647\u0631\u0627\u0632",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Dhar Al Mehraz",
     "wof:parent_id":890454333,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/189/993/421189993.geojson
+++ b/data/421/189/993/421189993.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673887,
-        890454333
+        890454333,
+        85673887
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189993,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423088,
     "wof:name":"Dhar Al Mehraz",
     "wof:parent_id":890454333,
     "wof:placetype":"locality",

--- a/data/421/190/003/421190003.geojson
+++ b/data/421/190/003/421190003.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0643\u062f\u0632"
+    ],
+    "name:eng_x_preferred":[
+        "Agdz"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190003,
-    "wof:lastmodified":1566601975,
-    "wof:name":"\u0627\u0643\u062f\u0632",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Agdz",
     "wof:parent_id":890424149,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/003/421190003.geojson
+++ b/data/421/190/003/421190003.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        890424149
+        890424149,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190003,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423083,
     "wof:name":"Agdz",
     "wof:parent_id":890424149,
     "wof:placetype":"locality",

--- a/data/421/190/005/421190005.geojson
+++ b/data/421/190/005/421190005.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062d\u0633\u064a\u0645\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Hoceima"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190005,
-    "wof:lastmodified":1566601975,
-    "wof:name":"\u0627\u0644\u062d\u0633\u064a\u0645\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Hoceima",
     "wof:parent_id":890429097,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/005/421190005.geojson
+++ b/data/421/190/005/421190005.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673893,
-        890429097
+        890429097,
+        85673893
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190005,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Hoceima",
     "wof:parent_id":890429097,
     "wof:placetype":"locality",

--- a/data/421/190/007/421190007.geojson
+++ b/data/421/190/007/421190007.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673911,
-        890453897
+        890453897,
+        85673911
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190007,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Khemisset",
     "wof:parent_id":890453897,
     "wof:placetype":"locality",

--- a/data/421/190/007/421190007.geojson
+++ b/data/421/190/007/421190007.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062e\u0645\u064a\u0633\u0627\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Al Khemisset"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190007,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u0627\u0644\u062e\u0645\u064a\u0633\u0627\u062a",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Khemisset",
     "wof:parent_id":890453897,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/009/421190009.geojson
+++ b/data/421/190/009/421190009.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        1108784843
+        1108784843,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190009,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"Amerzgane",
     "wof:parent_id":1108784843,
     "wof:placetype":"locality",

--- a/data/421/190/009/421190009.geojson
+++ b/data/421/190/009/421190009.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0645\u0631\u0632\u0643\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Amerzgane"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190009,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u0627\u0645\u0631\u0632\u0643\u0627\u0646",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Amerzgane",
     "wof:parent_id":1108784843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/023/421190023.geojson
+++ b/data/421/190/023/421190023.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673923,
-        1108784771
+        1108784771,
+        85673923
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190023,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Burkan",
     "wof:parent_id":1108784771,
     "wof:placetype":"locality",

--- a/data/421/190/023/421190023.geojson
+++ b/data/421/190/023/421190023.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0631\u0643\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Burkan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190023,
-    "wof:lastmodified":1566601972,
-    "wof:name":"\u0628\u0631\u0643\u0627\u0646",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Burkan",
     "wof:parent_id":1108784771,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/027/421190027.geojson
+++ b/data/421/190/027/421190027.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0648\u0633\u0643\u0648\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Bouskoura"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190027,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u0628\u0648\u0633\u0643\u0648\u0631\u0629",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bouskoura",
     "wof:parent_id":890424145,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/027/421190027.geojson
+++ b/data/421/190/027/421190027.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673901,
-        890424145
+        890424145,
+        85673901
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190027,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Bouskoura",
     "wof:parent_id":890424145,
     "wof:placetype":"locality",

--- a/data/421/190/031/421190031.geojson
+++ b/data/421/190/031/421190031.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0634\u064a\u0634\u0627\u0648\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Chichaoua"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190031,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u0634\u064a\u0634\u0627\u0648\u0629",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Chichaoua",
     "wof:parent_id":890440847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/031/421190031.geojson
+++ b/data/421/190/031/421190031.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673933,
-        890440847
+        890440847,
+        85673933
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190031,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423088,
     "wof:name":"Chichaoua",
     "wof:parent_id":890440847,
     "wof:placetype":"locality",

--- a/data/421/190/039/421190039.geojson
+++ b/data/421/190/039/421190039.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673883,
-        890453883
+        890453883,
+        85673883
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190039,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Jubeiha",
     "wof:parent_id":890453883,
     "wof:placetype":"locality",

--- a/data/421/190/039/421190039.geojson
+++ b/data/421/190/039/421190039.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062c\u0628\u0647\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Jubeiha"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190039,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u062c\u0628\u0647\u0629",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Jubeiha",
     "wof:parent_id":890453883,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/041/421190041.geojson
+++ b/data/421/190/041/421190041.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673937,
-        890445399
+        890445399,
+        85673937
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190041,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Jadida",
     "wof:parent_id":890445399,
     "wof:placetype":"locality",

--- a/data/421/190/041/421190041.geojson
+++ b/data/421/190/041/421190041.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062c\u062f\u064a\u062f\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Jadida"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190041,
-    "wof:lastmodified":1566601972,
-    "wof:name":"\u0627\u0644\u062c\u062f\u064a\u062f\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Jadida",
     "wof:parent_id":890445399,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/043/421190043.geojson
+++ b/data/421/190/043/421190043.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673915,
-        1108784773
+        1108784773,
+        85673915
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190043,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423087,
     "wof:name":"Ar Rashidiya",
     "wof:parent_id":1108784773,
     "wof:placetype":"locality",

--- a/data/421/190/043/421190043.geojson
+++ b/data/421/190/043/421190043.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u0627\u0634\u062f\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ar Rashidiya"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190043,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u0627\u0644\u0631\u0627\u0634\u062f\u064a\u0629",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Ar Rashidiya",
     "wof:parent_id":1108784773,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/047/421190047.geojson
+++ b/data/421/190/047/421190047.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673887,
-        890454333
+        890454333,
+        85673887
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190047,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423089,
     "wof:name":"Fes Jdid",
     "wof:parent_id":890454333,
     "wof:placetype":"locality",

--- a/data/421/190/047/421190047.geojson
+++ b/data/421/190/047/421190047.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0641\u0627\u0633 \u0627\u0644\u062c\u062f\u064a\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Fes Jdid"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190047,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u0641\u0627\u0633 \u0627\u0644\u062c\u062f\u064a\u062f",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Fes Jdid",
     "wof:parent_id":890454333,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/053/421190053.geojson
+++ b/data/421/190/053/421190053.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0643\u0644\u0645\u064a\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Guelmim"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190053,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u0643\u0644\u0645\u064a\u0645",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Guelmim",
     "wof:parent_id":1108784815,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/053/421190053.geojson
+++ b/data/421/190/053/421190053.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673947,
-        1108784815
+        1108784815,
+        85673947
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190053,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423089,
     "wof:name":"Guelmim",
     "wof:parent_id":1108784815,
     "wof:placetype":"locality",

--- a/data/421/190/057/421190057.geojson
+++ b/data/421/190/057/421190057.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673933,
-        1108784829
+        1108784829,
+        85673933
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190057,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423089,
     "wof:name":"Gueliz",
     "wof:parent_id":1108784829,
     "wof:placetype":"locality",

--- a/data/421/190/057/421190057.geojson
+++ b/data/421/190/057/421190057.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0643\u0644\u064a\u0632"
+    ],
+    "name:eng_x_preferred":[
+        "Gueliz"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190057,
-    "wof:lastmodified":1566601975,
-    "wof:name":"\u0643\u0644\u064a\u0632",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Gueliz",
     "wof:parent_id":1108784829,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/059/421190059.geojson
+++ b/data/421/190/059/421190059.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-5.112247,33.5330125,-5.112247,33.5330125",
+    "geom:bbox":"-5.112247,33.533012,-5.112247,33.533012",
     "geom:latitude":33.533012,
     "geom:longitude":-5.112247,
     "iso:country":"MA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673915,
-        890429095
+        890429095,
+        85673915
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"MA",
     "wof:created":1459009644,
-    "wof:geomhash":"50a89181b786718ae1884ea32507e08c",
+    "wof:geomhash":"06bc0017adb381f2ffd5ad7fd2e5deec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190059,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423089,
     "wof:name":"Ifran",
     "wof:parent_id":890429095,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     -5.112247,
-    33.5330125,
+    33.533012,
     -5.112247,
-    33.5330125
+    33.533012
 ],
-  "geometry": {"coordinates":[-5.112247,33.5330125],"type":"Point"}
+  "geometry": {"coordinates":[-5.112247,33.533012],"type":"Point"}
 }

--- a/data/421/190/059/421190059.geojson
+++ b/data/421/190/059/421190059.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0641\u0631\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Ifran"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190059,
-    "wof:lastmodified":1566601975,
-    "wof:name":"\u0627\u0641\u0631\u0627\u0646",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Ifran",
     "wof:parent_id":890429095,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/063/421190063.geojson
+++ b/data/421/190/063/421190063.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u063a\u064a\u0631\u0645 \u0646\u0648\u0643\u062f\u0627\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Ighrem N'ougdal"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190063,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u0627\u063a\u064a\u0631\u0645 \u0646\u0648\u0643\u062f\u0627\u0644",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Ighrem N'ougdal",
     "wof:parent_id":1108784843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/063/421190063.geojson
+++ b/data/421/190/063/421190063.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-7.4010605,31.270334,-7.4010605,31.270334",
+    "geom:bbox":"-7.40106,31.270334,-7.40106,31.270334",
     "geom:latitude":31.270334,
     "geom:longitude":-7.40106,
     "iso:country":"MA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        1108784843
+        1108784843,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"MA",
     "wof:created":1459009645,
-    "wof:geomhash":"6ae3e46f819d331aaeafa0d387823a58",
+    "wof:geomhash":"91845e636cc4409d10f6ea5b27d62152",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190063,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423089,
     "wof:name":"Ighrem N'ougdal",
     "wof:parent_id":1108784843,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -7.4010605,
+    -7.40106,
     31.270334,
-    -7.4010605,
+    -7.40106,
     31.270334
 ],
-  "geometry": {"coordinates":[-7.4010605,31.270334],"type":"Point"}
+  "geometry": {"coordinates":[-7.40106,31.270334],"type":"Point"}
 }

--- a/data/421/190/065/421190065.geojson
+++ b/data/421/190/065/421190065.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0645\u0627\u0633\u064a\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Amassine"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190065,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u0627\u0645\u0627\u0633\u064a\u0646",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Amassine",
     "wof:parent_id":1108784843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/065/421190065.geojson
+++ b/data/421/190/065/421190065.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-6.3475505,31.141052,-6.3475505,31.141052",
+    "geom:bbox":"-6.34755,31.141052,-6.34755,31.141052",
     "geom:latitude":31.141052,
     "geom:longitude":-6.34755,
     "iso:country":"MA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        1108784843
+        1108784843,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"MA",
     "wof:created":1459009645,
-    "wof:geomhash":"89c11d966bb454bdcf25f5fc0075295d",
+    "wof:geomhash":"df52cdeadc08ddbd83f9c8d8bce0a2e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190065,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"Amassine",
     "wof:parent_id":1108784843,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -6.3475505,
+    -6.34755,
     31.141052,
-    -6.3475505,
+    -6.34755,
     31.141052
 ],
-  "geometry": {"coordinates":[-6.3475505,31.141052],"type":"Point"}
+  "geometry": {"coordinates":[-6.34755,31.141052],"type":"Point"}
 }

--- a/data/421/190/067/421190067.geojson
+++ b/data/421/190/067/421190067.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673897,
-        890427533
+        890427533,
+        85673897
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190067,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Qunitira",
     "wof:parent_id":890427533,
     "wof:placetype":"locality",

--- a/data/421/190/067/421190067.geojson
+++ b/data/421/190/067/421190067.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0642\u0646\u064a\u0637\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Qunitira"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190067,
-    "wof:lastmodified":1566601975,
-    "wof:name":"\u0627\u0644\u0642\u0646\u064a\u0637\u0631\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Qunitira",
     "wof:parent_id":890427533,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/069/421190069.geojson
+++ b/data/421/190/069/421190069.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0639\u0631\u0627\u064a\u0634"
+    ],
+    "name:eng_x_preferred":[
+        "Larache"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190069,
-    "wof:lastmodified":1566601975,
-    "wof:name":"\u0627\u0644\u0639\u0631\u0627\u064a\u0634",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Larache",
     "wof:parent_id":890422513,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/069/421190069.geojson
+++ b/data/421/190/069/421190069.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673883,
-        890422513
+        890422513,
+        85673883
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190069,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423090,
     "wof:name":"Larache",
     "wof:parent_id":890422513,
     "wof:placetype":"locality",

--- a/data/421/190/071/421190071.geojson
+++ b/data/421/190/071/421190071.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673915,
-        1108784791
+        1108784791,
+        85673915
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190071,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423090,
     "wof:name":"Khenifra",
     "wof:parent_id":1108784791,
     "wof:placetype":"locality",

--- a/data/421/190/071/421190071.geojson
+++ b/data/421/190/071/421190071.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062e\u0646\u064a\u0641\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Khenifra"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190071,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u062e\u0646\u064a\u0641\u0631\u0629",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Khenifra",
     "wof:parent_id":1108784791,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/081/421190081.geojson
+++ b/data/421/190/081/421190081.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0633\u0645\u0631\u064a\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "M'semrir"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190081,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u0645\u0633\u0645\u0631\u064a\u0631",
+    "wof:lastmodified":1601068400,
+    "wof:name":"M'semrir",
     "wof:parent_id":1108784839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/081/421190081.geojson
+++ b/data/421/190/081/421190081.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        1108784839
+        1108784839,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190081,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"M'semrir",
     "wof:parent_id":1108784839,
     "wof:placetype":"locality",

--- a/data/421/190/083/421190083.geojson
+++ b/data/421/190/083/421190083.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673915,
-        1108784791
+        1108784791,
+        85673915
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190083,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"M'rirt",
     "wof:parent_id":1108784791,
     "wof:placetype":"locality",

--- a/data/421/190/083/421190083.geojson
+++ b/data/421/190/083/421190083.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0631\u064a\u0631\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "M'rirt"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190083,
-    "wof:lastmodified":1566601972,
-    "wof:name":"\u0645\u0631\u064a\u0631\u062a",
+    "wof:lastmodified":1601068400,
+    "wof:name":"M'rirt",
     "wof:parent_id":1108784791,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/085/421190085.geojson
+++ b/data/421/190/085/421190085.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673923,
-        890455271
+        890455271,
+        85673923
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190085,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Nador",
     "wof:parent_id":890455271,
     "wof:placetype":"locality",

--- a/data/421/190/085/421190085.geojson
+++ b/data/421/190/085/421190085.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0646\u0627\u0636\u0648\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Al Nador"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190085,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u0627\u0644\u0646\u0627\u0636\u0648\u0631",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Nador",
     "wof:parent_id":890455271,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/087/421190087.geojson
+++ b/data/421/190/087/421190087.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673937,
-        1108784819
+        1108784819,
+        85673937
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190087,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423094,
     "wof:name":"Walidia",
     "wof:parent_id":1108784819,
     "wof:placetype":"locality",

--- a/data/421/190/087/421190087.geojson
+++ b/data/421/190/087/421190087.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0627\u0644\u062f\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Walidia"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190087,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u0648\u0627\u0644\u062f\u064a\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Walidia",
     "wof:parent_id":1108784819,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/089/421190089.geojson
+++ b/data/421/190/089/421190089.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0631\u0632\u0632\u0627\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Ouarzazate"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190089,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u0648\u0631\u0632\u0632\u0627\u062a",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Ouarzazate",
     "wof:parent_id":1108784843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/089/421190089.geojson
+++ b/data/421/190/089/421190089.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        1108784843
+        1108784843,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190089,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423091,
     "wof:name":"Ouarzazate",
     "wof:parent_id":1108784843,
     "wof:placetype":"locality",

--- a/data/421/190/095/421190095.geojson
+++ b/data/421/190/095/421190095.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673883,
-        1108784797
+        1108784797,
+        85673883
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190095,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423091,
     "wof:name":"Quazzane",
     "wof:parent_id":1108784797,
     "wof:placetype":"locality",

--- a/data/421/190/095/421190095.geojson
+++ b/data/421/190/095/421190095.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0632\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Quazzane"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190095,
-    "wof:lastmodified":1566601975,
-    "wof:name":"\u0648\u0632\u0627\u0646",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Quazzane",
     "wof:parent_id":1108784797,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/099/421190099.geojson
+++ b/data/421/190/099/421190099.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673901,
-        1108784833
+        1108784833,
+        85673901
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190099,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Settat",
     "wof:parent_id":1108784833,
     "wof:placetype":"locality",

--- a/data/421/190/099/421190099.geojson
+++ b/data/421/190/099/421190099.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u0637\u0627\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Settat"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190099,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u0633\u0637\u0627\u062a",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Settat",
     "wof:parent_id":1108784833,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/101/421190101.geojson
+++ b/data/421/190/101/421190101.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0648\u0632\u0648\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Ouzoud"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190101,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u0627\u0648\u0632\u0648\u062f",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Ouzoud",
     "wof:parent_id":1108784827,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/101/421190101.geojson
+++ b/data/421/190/101/421190101.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673919,
-        1108784827
+        1108784827,
+        85673919
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190101,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423091,
     "wof:name":"Ouzoud",
     "wof:parent_id":1108784827,
     "wof:placetype":"locality",

--- a/data/421/190/103/421190103.geojson
+++ b/data/421/190/103/421190103.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673911,
-        890437999
+        890437999,
+        85673911
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190103,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423091,
     "wof:name":"Rabat",
     "wof:parent_id":890437999,
     "wof:placetype":"locality",

--- a/data/421/190/103/421190103.geojson
+++ b/data/421/190/103/421190103.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u0628\u0627\u0637"
+    ],
+    "name:eng_x_preferred":[
+        "Rabat"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190103,
-    "wof:lastmodified":1566601972,
-    "wof:name":"\u0627\u0644\u0631\u0628\u0627\u0637",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Rabat",
     "wof:parent_id":890437999,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/105/421190105.geojson
+++ b/data/421/190/105/421190105.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u064a\u0633\u0627\u0646\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Al Rissani"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190105,
-    "wof:lastmodified":1566601972,
-    "wof:name":"\u0627\u0644\u0631\u064a\u0633\u0627\u0646\u064a",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Rissani",
     "wof:parent_id":1108784773,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/105/421190105.geojson
+++ b/data/421/190/105/421190105.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673915,
-        1108784773
+        1108784773,
+        85673915
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190105,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Rissani",
     "wof:parent_id":1108784773,
     "wof:placetype":"locality",

--- a/data/421/190/107/421190107.geojson
+++ b/data/421/190/107/421190107.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0633\u0641\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Asfi"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190107,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u0627\u0633\u0641\u064a",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Asfi",
     "wof:parent_id":890445397,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/107/421190107.geojson
+++ b/data/421/190/107/421190107.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673937,
-        890445397
+        890445397,
+        85673937
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190107,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Asfi",
     "wof:parent_id":890445397,
     "wof:placetype":"locality",

--- a/data/421/190/115/421190115.geojson
+++ b/data/421/190/115/421190115.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u064a\u062f\u064a \u0627\u0644\u0645\u062e\u062a\u0627\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Sidi Al Mukhtar"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190115,
-    "wof:lastmodified":1566601975,
-    "wof:name":"\u0633\u064a\u062f\u064a \u0627\u0644\u0645\u062e\u062a\u0627\u0631",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sidi Al Mukhtar",
     "wof:parent_id":890440847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/115/421190115.geojson
+++ b/data/421/190/115/421190115.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673933,
-        890440847
+        890440847,
+        85673933
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190115,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sidi Al Mukhtar",
     "wof:parent_id":890440847,
     "wof:placetype":"locality",

--- a/data/421/190/117/421190117.geojson
+++ b/data/421/190/117/421190117.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u064a\u062f\u064a \u0642\u0627\u0633\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Sidi Qasim"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190117,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u0633\u064a\u062f\u064a \u0642\u0627\u0633\u0645",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sidi Qasim",
     "wof:parent_id":890429091,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/117/421190117.geojson
+++ b/data/421/190/117/421190117.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673897,
-        890429091
+        890429091,
+        85673897
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190117,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sidi Qasim",
     "wof:parent_id":890429091,
     "wof:placetype":"locality",

--- a/data/421/190/119/421190119.geojson
+++ b/data/421/190/119/421190119.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u064a\u062f\u064a \u0633\u0644\u064a\u0645\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Sidi Sliman"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190119,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u0633\u064a\u062f\u064a \u0633\u0644\u064a\u0645\u0627\u0646",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sidi Sliman",
     "wof:parent_id":1108784809,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/119/421190119.geojson
+++ b/data/421/190/119/421190119.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673897,
-        1108784809
+        1108784809,
+        85673897
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190119,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sidi Sliman",
     "wof:parent_id":1108784809,
     "wof:placetype":"locality",

--- a/data/421/190/121/421190121.geojson
+++ b/data/421/190/121/421190121.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u062d\u0646\u0627\u0648\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Tahannout"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190121,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u062a\u062d\u0646\u0627\u0648\u062a",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Tahannout",
     "wof:parent_id":1108784801,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/121/421190121.geojson
+++ b/data/421/190/121/421190121.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673933,
-        1108784801
+        1108784801,
+        85673933
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190121,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tahannout",
     "wof:parent_id":1108784801,
     "wof:placetype":"locality",

--- a/data/421/190/123/421190123.geojson
+++ b/data/421/190/123/421190123.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0637\u0646\u062c\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Tangier"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190123,
-    "wof:lastmodified":1566601975,
-    "wof:name":"\u0637\u0646\u062c\u0629",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Tangier",
     "wof:parent_id":85673883,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/123/421190123.geojson
+++ b/data/421/190/123/421190123.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190123,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tangier",
     "wof:parent_id":85673883,
     "wof:placetype":"locality",

--- a/data/421/190/125/421190125.geojson
+++ b/data/421/190/125/421190125.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u0645\u0646\u0627\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Tamanar"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190125,
-    "wof:lastmodified":1566601975,
-    "wof:name":"\u062a\u0645\u0646\u0627\u0631",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Tamanar",
     "wof:parent_id":890453939,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/125/421190125.geojson
+++ b/data/421/190/125/421190125.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673933,
-        890453939
+        890453939,
+        85673933
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190125,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tamanar",
     "wof:parent_id":890453939,
     "wof:placetype":"locality",

--- a/data/421/190/129/421190129.geojson
+++ b/data/421/190/129/421190129.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0637\u0627\u0646\u0637\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Tan-Tan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190129,
-    "wof:lastmodified":1566601973,
-    "wof:name":"\u0637\u0627\u0646\u0637\u0627\u0646",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Tan-Tan",
     "wof:parent_id":890418107,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/129/421190129.geojson
+++ b/data/421/190/129/421190129.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673947,
-        890418107
+        890418107,
+        85673947
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190129,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tan-Tan",
     "wof:parent_id":890418107,
     "wof:placetype":"locality",

--- a/data/421/190/131/421190131.geojson
+++ b/data/421/190/131/421190131.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u0627\u0631\u0648\u062f\u0627\u0646\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Taroudant"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190131,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u062a\u0627\u0631\u0648\u062f\u0627\u0646\u062a",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Taroudant",
     "wof:parent_id":890445395,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/131/421190131.geojson
+++ b/data/421/190/131/421190131.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        890445395
+        890445395,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190131,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Taroudant",
     "wof:parent_id":890445395,
     "wof:placetype":"locality",

--- a/data/421/190/133/421190133.geojson
+++ b/data/421/190/133/421190133.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u0627\u0632\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Taza"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190133,
-    "wof:lastmodified":1566601972,
-    "wof:name":"\u062a\u0627\u0632\u0629",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Taza",
     "wof:parent_id":890436791,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/133/421190133.geojson
+++ b/data/421/190/133/421190133.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673893,
-        890436791
+        890436791,
+        85673893
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190133,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Taza",
     "wof:parent_id":890436791,
     "wof:placetype":"locality",

--- a/data/421/190/135/421190135.geojson
+++ b/data/421/190/135/421190135.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u0627\u0632\u0627\u062e\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Tasakht"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190135,
-    "wof:lastmodified":1566601972,
-    "wof:name":"\u062a\u0627\u0632\u0627\u062e\u062a",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Tasakht",
     "wof:parent_id":1108784839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/135/421190135.geojson
+++ b/data/421/190/135/421190135.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        1108784839
+        1108784839,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190135,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tasakht",
     "wof:parent_id":1108784839,
     "wof:placetype":"locality",

--- a/data/421/190/137/421190137.geojson
+++ b/data/421/190/137/421190137.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u064a\u063a\u0633\u0627\u0644\u064a\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Tighassaline"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190137,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u062a\u064a\u063a\u0633\u0627\u0644\u064a\u0646",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Tighassaline",
     "wof:parent_id":1108784791,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/137/421190137.geojson
+++ b/data/421/190/137/421190137.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673915,
-        1108784791
+        1108784791,
+        85673915
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190137,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tighassaline",
     "wof:parent_id":1108784791,
     "wof:placetype":"locality",

--- a/data/421/190/139/421190139.geojson
+++ b/data/421/190/139/421190139.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u064a\u0646\u063a\u064a\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Tinghir"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190139,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u062a\u064a\u0646\u063a\u064a\u0631",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Tinghir",
     "wof:parent_id":1108784839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/139/421190139.geojson
+++ b/data/421/190/139/421190139.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        1108784839
+        1108784839,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190139,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tinghir",
     "wof:parent_id":1108784839,
     "wof:placetype":"locality",

--- a/data/421/190/147/421190147.geojson
+++ b/data/421/190/147/421190147.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        890424149
+        890424149,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190147,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423094,
     "wof:name":"Zagora",
     "wof:parent_id":890424149,
     "wof:placetype":"locality",

--- a/data/421/190/147/421190147.geojson
+++ b/data/421/190/147/421190147.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0632\u0627\u0643\u0648\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Zagora"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190147,
-    "wof:lastmodified":1566601976,
-    "wof:name":"\u0632\u0627\u0643\u0648\u0631\u0629",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Zagora",
     "wof:parent_id":890424149,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/190/153/421190153.geojson
+++ b/data/421/190/153/421190153.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673915,
-        890429095
+        890429095,
+        85673915
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190153,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Timahdite",
     "wof:parent_id":890429095,
     "wof:placetype":"locality",

--- a/data/421/190/153/421190153.geojson
+++ b/data/421/190/153/421190153.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u064a\u0645\u062d\u0636\u064a\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Timahdite"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190153,
-    "wof:lastmodified":1566601974,
-    "wof:name":"\u062a\u064a\u0645\u062d\u0636\u064a\u062a",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Timahdite",
     "wof:parent_id":890429095,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/191/723/421191723.geojson
+++ b/data/421/191/723/421191723.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-5.2815015,35.6288875,-5.2815015,35.6288875",
+    "geom:bbox":"-5.281502,35.628887,-5.281502,35.628887",
     "geom:latitude":35.628887,
     "geom:longitude":-5.281502,
     "iso:country":"MA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673883,
-        1108784777
+        1108784777,
+        85673883
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"MA",
     "wof:created":1459009703,
-    "wof:geomhash":"f9797a5c43a9f8b3fbe04638f61792d7",
+    "wof:geomhash":"961d53491c3042d55b750302d1f582de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191723,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Martil",
     "wof:parent_id":1108784777,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -5.2815015,
-    35.6288875,
-    -5.2815015,
-    35.6288875
+    -5.281502,
+    35.628887,
+    -5.281502,
+    35.628887
 ],
-  "geometry": {"coordinates":[-5.2815015,35.6288875],"type":"Point"}
+  "geometry": {"coordinates":[-5.281502,35.628887],"type":"Point"}
 }

--- a/data/421/191/723/421191723.geojson
+++ b/data/421/191/723/421191723.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0627\u0631\u062a\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Martil"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191723,
-    "wof:lastmodified":1566601972,
-    "wof:name":"\u0645\u0627\u0631\u062a\u064a\u0644",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Martil",
     "wof:parent_id":1108784777,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/192/693/421192693.geojson
+++ b/data/421/192/693/421192693.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0631\u0632\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Arazan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421192693,
-    "wof:lastmodified":1566601967,
-    "wof:name":"\u0627\u0631\u0632\u0627\u0646",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Arazan",
     "wof:parent_id":890445395,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/192/693/421192693.geojson
+++ b/data/421/192/693/421192693.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        890445395
+        890445395,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421192693,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Arazan",
     "wof:parent_id":890445395,
     "wof:placetype":"locality",

--- a/data/421/199/989/421199989.geojson
+++ b/data/421/199/989/421199989.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u064a\u062f\u0644\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Midelt"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421199989,
-    "wof:lastmodified":1566601976,
-    "wof:name":"\u0645\u064a\u062f\u0644\u062a",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Midelt",
     "wof:parent_id":1108784795,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/199/989/421199989.geojson
+++ b/data/421/199/989/421199989.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673915,
-        1108784795
+        1108784795,
+        85673915
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421199989,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423090,
     "wof:name":"Midelt",
     "wof:parent_id":1108784795,
     "wof:placetype":"locality",

--- a/data/421/199/993/421199993.geojson
+++ b/data/421/199/993/421199993.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u062d\u0645\u062f\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mohammedia"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421199993,
-    "wof:lastmodified":1566601976,
-    "wof:name":"\u0627\u0644\u0645\u062d\u0645\u062f\u064a\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mohammedia",
     "wof:parent_id":890424147,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/199/993/421199993.geojson
+++ b/data/421/199/993/421199993.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673901,
-        890424147
+        890424147,
+        85673901
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421199993,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mohammedia",
     "wof:parent_id":890424147,
     "wof:placetype":"locality",

--- a/data/421/200/917/421200917.geojson
+++ b/data/421/200/917/421200917.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673933,
-        1108784801
+        1108784801,
+        85673933
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200917,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Asni",
     "wof:parent_id":1108784801,
     "wof:placetype":"locality",

--- a/data/421/200/917/421200917.geojson
+++ b/data/421/200/917/421200917.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0633\u0646\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Asni"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200917,
-    "wof:lastmodified":1566601976,
-    "wof:name":"\u0627\u0633\u0646\u064a",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Asni",
     "wof:parent_id":1108784801,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/200/919/421200919.geojson
+++ b/data/421/200/919/421200919.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673915,
-        890429095
+        890429095,
+        85673915
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200919,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Azrou",
     "wof:parent_id":890429095,
     "wof:placetype":"locality",

--- a/data/421/200/919/421200919.geojson
+++ b/data/421/200/919/421200919.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0632\u0631\u0648"
+    ],
+    "name:eng_x_preferred":[
+        "Azrou"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200919,
-    "wof:lastmodified":1566601976,
-    "wof:name":"\u0627\u0632\u0631\u0648",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Azrou",
     "wof:parent_id":890429095,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/200/921/421200921.geojson
+++ b/data/421/200/921/421200921.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u062c\u062f\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Oujda"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200921,
-    "wof:lastmodified":1566601976,
-    "wof:name":"\u0648\u062c\u062f\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Oujda",
     "wof:parent_id":890453895,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/200/921/421200921.geojson
+++ b/data/421/200/921/421200921.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673923,
-        890453895
+        890453895,
+        85673923
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200921,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423091,
     "wof:name":"Oujda",
     "wof:parent_id":890453895,
     "wof:placetype":"locality",

--- a/data/421/202/335/421202335.geojson
+++ b/data/421/202/335/421202335.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0639\u064a\u0648\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Laayoune"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421202335,
-    "wof:lastmodified":1566601970,
-    "wof:name":"\u0627\u0644\u0639\u064a\u0648\u0646",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Laayoune",
     "wof:parent_id":85673941,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/202/335/421202335.geojson
+++ b/data/421/202/335/421202335.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421202335,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423090,
     "wof:name":"Laayoune",
     "wof:parent_id":85673941,
     "wof:placetype":"locality",

--- a/data/421/202/341/421202341.geojson
+++ b/data/421/202/341/421202341.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0648\u0645\u0627\u0644\u0646 \u062f\u0627\u062f\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Boumalne Dades"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202341,
-    "wof:lastmodified":1566601970,
-    "wof:name":"\u0628\u0648\u0645\u0627\u0644\u0646 \u062f\u0627\u062f\u0633",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Boumalne Dades",
     "wof:parent_id":1108784839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",

--- a/data/421/202/341/421202341.geojson
+++ b/data/421/202/341/421202341.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673929,
-        1108784839
+        1108784839,
+        85673929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202341,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Boumalne Dades",
     "wof:parent_id":1108784839,
     "wof:placetype":"locality",

--- a/data/421/202/343/421202343.geojson
+++ b/data/421/202/343/421202343.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632693,
-        85673901,
-        890436421
+        890436421,
+        85673901
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202343,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Bouznika",
     "wof:parent_id":890436421,
     "wof:placetype":"locality",

--- a/data/421/202/343/421202343.geojson
+++ b/data/421/202/343/421202343.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0648\u0632\u0646\u064a\u0642\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Bouznika"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202343,
-    "wof:lastmodified":1566601970,
-    "wof:name":"\u0628\u0648\u0632\u0646\u064a\u0642\u0629",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bouznika",
     "wof:parent_id":890436421,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ma",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.