### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/110/878/477/1/1108784771.geojson
+++ b/data/110/878/477/1/1108784771.geojson
@@ -93,6 +93,12 @@
     "name:swe_x_preferred":[
         "Berkane-Taourirt"
     ],
+    "name:swe_x_variant":[
+        "Berkane"
+    ],
+    "name:tur_x_preferred":[
+        "Burkan"
+    ],
     "name:urd_x_preferred":[
         "\u0628\u0631\u06a9\u0627\u0646 \u0635\u0648\u0628\u06c1"
     ],
@@ -135,7 +141,7 @@
         }
     ],
     "wof:id":1108784771,
-    "wof:lastmodified":1669159676,
+    "wof:lastmodified":1690938913,
     "wof:name":"Berkane",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/110/878/477/3/1108784773.geojson
+++ b/data/110/878/477/3/1108784773.geojson
@@ -93,11 +93,17 @@
     "name:ron_x_preferred":[
         "Errachidia"
     ],
+    "name:rus_x_preferred":[
+        "\u042d\u0440\u0440\u0430\u0445\u0438\u0434\u0438\u044f"
+    ],
     "name:spa_x_preferred":[
         "Provincia de Errachidia"
     ],
     "name:swe_x_preferred":[
         "Errachidia"
+    ],
+    "name:tur_x_preferred":[
+        "Er-Ra\u015fidiye"
     ],
     "name:zho_x_preferred":[
         "\u62c9\u5e0c\u8fea\u8036\u7701"
@@ -138,7 +144,7 @@
         }
     ],
     "wof:id":1108784773,
-    "wof:lastmodified":1669157463,
+    "wof:lastmodified":1690938914,
     "wof:name":"Errachidia",
     "wof:parent_id":1796661363,
     "wof:placetype":"county",

--- a/data/110/878/477/5/1108784775.geojson
+++ b/data/110/878/477/5/1108784775.geojson
@@ -90,6 +90,9 @@
     "name:swe_x_preferred":[
         "Jerada"
     ],
+    "name:tur_x_preferred":[
+        "Cerada"
+    ],
     "name:urd_x_preferred":[
         "\u062c\u0631\u0627\u062f\u06c1 \u0635\u0648\u0628\u06c1"
     ],
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":1108784775,
-    "wof:lastmodified":1669159677,
+    "wof:lastmodified":1690938914,
     "wof:name":"Jerada",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/110/878/477/7/1108784777.geojson
+++ b/data/110/878/477/7/1108784777.geojson
@@ -52,7 +52,8 @@
         "M'diq Fnidq"
     ],
     "name:eng_x_variant":[
-        "M'diq-Fnideq"
+        "M'diq-Fnideq",
+        "M'diq-Fnideq Prefecture"
     ],
     "name:fra_x_preferred":[
         "pr\u00e9fecture de M'diq-Fnideq"
@@ -71,6 +72,12 @@
     ],
     "name:spa_x_preferred":[
         "M'Diq-Fnideq"
+    ],
+    "name:swe_x_preferred":[
+        "M'Diq-Fnideq"
+    ],
+    "name:tur_x_preferred":[
+        "Madik-Funeydek"
     ],
     "name:zho_x_preferred":[
         "\u9081\u8fea\u683c\u7701"
@@ -111,7 +118,7 @@
         }
     ],
     "wof:id":1108784777,
-    "wof:lastmodified":1669161174,
+    "wof:lastmodified":1690938913,
     "wof:name":"M'diq-Fnideq",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/110/878/477/9/1108784779.geojson
+++ b/data/110/878/477/9/1108784779.geojson
@@ -81,6 +81,12 @@
     "name:spa_x_preferred":[
         "Provincia de Driouch"
     ],
+    "name:swe_x_preferred":[
+        "Driouch"
+    ],
+    "name:tur_x_preferred":[
+        "Drive\u015f"
+    ],
     "name:urd_x_preferred":[
         "\u062f\u0631\u06cc\u0648\u0634 \u0635\u0648\u0628\u06c1"
     ],
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":1108784779,
-    "wof:lastmodified":1669159675,
+    "wof:lastmodified":1690938913,
     "wof:name":"Driouch",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/110/878/478/5/1108784785.geojson
+++ b/data/110/878/478/5/1108784785.geojson
@@ -96,6 +96,12 @@
     "name:swe_x_preferred":[
         "Kelaa-Des-Sraghna"
     ],
+    "name:swe_x_variant":[
+        "El Kela\u00e2 des Sraghna"
+    ],
+    "name:tur_x_preferred":[
+        "Kalet\u00fc's-Seragine"
+    ],
     "name:urd_x_preferred":[
         "\u0627\u0644\u0642\u0639\u06c1 \u0633\u0631\u0627\u063a\u0646\u06c1 \u0635\u0648\u0628\u06c1"
     ],
@@ -138,7 +144,7 @@
         }
     ],
     "wof:id":1108784785,
-    "wof:lastmodified":1669158638,
+    "wof:lastmodified":1690938911,
     "wof:name":"El Kelaat Es-Sraghna",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/110/878/478/7/1108784787.geojson
+++ b/data/110/878/478/7/1108784787.geojson
@@ -75,8 +75,17 @@
     "name:nan_x_preferred":[
         "Fquih Ben Salah S\u00e9ng"
     ],
+    "name:swe_x_preferred":[
+        "Fquih Ben Salah"
+    ],
+    "name:tur_x_preferred":[
+        "Fakih bin Salih"
+    ],
     "name:und_x_variant":[
         "\u0625\u0642\u0644\u064a\u0645 \u0627\u0644\u0641\u0642\u064a\u0647 \u0628\u0646 \u0635\u0627\u0644\u062d"
+    ],
+    "name:uzb_x_preferred":[
+        "Fquih Ben Salah viloyati"
     ],
     "name:zho_x_preferred":[
         "\u5f17\u57fa\u8d6b\u62dc\u5c3c\u585e\u62c9\u8d6b\u7701"
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":1108784787,
-    "wof:lastmodified":1669156509,
+    "wof:lastmodified":1690938911,
     "wof:name":"Fquih Ben Saleh",
     "wof:parent_id":1796661357,
     "wof:placetype":"county",

--- a/data/110/878/478/9/1108784789.geojson
+++ b/data/110/878/478/9/1108784789.geojson
@@ -90,6 +90,12 @@
     "name:spa_x_preferred":[
         "Provincia de El Hayeb"
     ],
+    "name:swe_x_preferred":[
+        "El Hajeb"
+    ],
+    "name:tur_x_preferred":[
+        "El-Hacib"
+    ],
     "name:zho_x_preferred":[
         "\u54c8\u5091\u535c\u7701"
     ],
@@ -129,7 +135,7 @@
         }
     ],
     "wof:id":1108784789,
-    "wof:lastmodified":1669157824,
+    "wof:lastmodified":1690938911,
     "wof:name":"El Hajeb",
     "wof:parent_id":1796661365,
     "wof:placetype":"county",

--- a/data/110/878/479/1/1108784791.geojson
+++ b/data/110/878/479/1/1108784791.geojson
@@ -84,6 +84,12 @@
     "name:spa_x_preferred":[
         "Provincia de Jenifra"
     ],
+    "name:swe_x_preferred":[
+        "Kh\u00e9nifra"
+    ],
+    "name:tur_x_preferred":[
+        "Henifre"
+    ],
     "name:zho_x_preferred":[
         "\u6d77\u5c3c\u592b\u62c9\u7701"
     ],
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":1108784791,
-    "wof:lastmodified":1669156509,
+    "wof:lastmodified":1690938916,
     "wof:name":"Khenifra",
     "wof:parent_id":1796661357,
     "wof:placetype":"county",

--- a/data/110/878/479/3/1108784793.geojson
+++ b/data/110/878/479/3/1108784793.geojson
@@ -81,6 +81,12 @@
     "name:por_x_preferred":[
         "Berrechid"
     ],
+    "name:swe_x_preferred":[
+        "Berrechid"
+    ],
+    "name:tur_x_preferred":[
+        "Birre\u015fid"
+    ],
     "name:urd_x_preferred":[
         "\u0628\u0631\u0634\u06cc\u062f \u0635\u0648\u0628\u06c1"
     ],
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":1108784793,
-    "wof:lastmodified":1669156886,
+    "wof:lastmodified":1690938916,
     "wof:name":"Berrechid",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/110/878/479/5/1108784795.geojson
+++ b/data/110/878/479/5/1108784795.geojson
@@ -78,6 +78,12 @@
     "name:spa_x_preferred":[
         "Provincia de Midelt"
     ],
+    "name:swe_x_preferred":[
+        "Midelt"
+    ],
+    "name:tur_x_preferred":[
+        "Midilt"
+    ],
     "name:zho_x_preferred":[
         "\u7c73\u5fb7\u52d2\u7279\u7701"
     ],
@@ -117,7 +123,7 @@
         }
     ],
     "wof:id":1108784795,
-    "wof:lastmodified":1669157462,
+    "wof:lastmodified":1690938917,
     "wof:name":"Midelt",
     "wof:parent_id":1796661363,
     "wof:placetype":"county",

--- a/data/110/878/479/7/1108784797.geojson
+++ b/data/110/878/479/7/1108784797.geojson
@@ -96,8 +96,14 @@
     "name:por_x_preferred":[
         "Ouezzane"
     ],
+    "name:swe_x_preferred":[
+        "Ouezzane"
+    ],
     "name:tur_x_preferred":[
         "Ouezzane"
+    ],
+    "name:tur_x_variant":[
+        "Vezz\u00e2n"
     ],
     "name:ukr_x_preferred":[
         "\u0423\u0430\u0437\u0437\u0430\u043d"
@@ -150,7 +156,7 @@
         }
     ],
     "wof:id":1108784797,
-    "wof:lastmodified":1669161175,
+    "wof:lastmodified":1690938916,
     "wof:name":"Ouezzane",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/110/878/480/1/1108784801.geojson
+++ b/data/110/878/480/1/1108784801.geojson
@@ -111,6 +111,12 @@
     "name:swe_x_preferred":[
         "Al-Haouz"
     ],
+    "name:swe_x_variant":[
+        "Al Haouz"
+    ],
+    "name:tur_x_preferred":[
+        "El-Havuz"
+    ],
     "name:ukr_x_preferred":[
         "\u041f\u0440\u043e\u0432\u0456\u043d\u0446\u0456\u044f \u0410\u043b\u044c-\u0425\u0430\u0443\u0437"
     ],
@@ -156,7 +162,7 @@
         }
     ],
     "wof:id":1108784801,
-    "wof:lastmodified":1669158639,
+    "wof:lastmodified":1690938918,
     "wof:name":"Al Haouz",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/110/878/480/3/1108784803.geojson
+++ b/data/110/878/480/3/1108784803.geojson
@@ -81,6 +81,12 @@
     "name:por_x_preferred":[
         "Rehamna"
     ],
+    "name:swe_x_preferred":[
+        "Rehamna"
+    ],
+    "name:tur_x_preferred":[
+        "Rahamine"
+    ],
     "name:urd_x_preferred":[
         "\u0631\u062d\u0627\u0645\u0646\u06c1 \u0635\u0648\u0628\u06c1"
     ],
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":1108784803,
-    "wof:lastmodified":1669158638,
+    "wof:lastmodified":1690938919,
     "wof:name":"Rhamna",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/110/878/480/5/1108784805.geojson
+++ b/data/110/878/480/5/1108784805.geojson
@@ -87,6 +87,12 @@
     "name:swe_x_preferred":[
         "Moulay-Yacoub"
     ],
+    "name:swe_x_variant":[
+        "Moulay Yacoub"
+    ],
+    "name:tur_x_preferred":[
+        "Mevley Yakub"
+    ],
     "name:zho_x_preferred":[
         "\u7a46\u96f7\u7701"
     ],
@@ -133,7 +139,7 @@
         }
     ],
     "wof:id":1108784805,
-    "wof:lastmodified":1669163211,
+    "wof:lastmodified":1690938919,
     "wof:name":"Moulay Yacoub",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/878/480/7/1108784807.geojson
+++ b/data/110/878/480/7/1108784807.geojson
@@ -75,6 +75,12 @@
     "name:nld_x_preferred":[
         "Guercif"
     ],
+    "name:swe_x_preferred":[
+        "Guercif"
+    ],
+    "name:tur_x_preferred":[
+        "Cirsif"
+    ],
     "name:urd_x_preferred":[
         "\u062c\u0631\u0633\u06cc\u0641 \u0635\u0648\u0628\u06c1"
     ],
@@ -117,7 +123,7 @@
         }
     ],
     "wof:id":1108784807,
-    "wof:lastmodified":1669159676,
+    "wof:lastmodified":1690938918,
     "wof:name":"Guercif",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/110/878/480/9/1108784809.geojson
+++ b/data/110/878/480/9/1108784809.geojson
@@ -78,6 +78,12 @@
     "name:por_x_preferred":[
         "Sidi Slimane"
     ],
+    "name:swe_x_preferred":[
+        "Sidi Slimane"
+    ],
+    "name:tur_x_preferred":[
+        "Sidi S\u00fcleyman"
+    ],
     "name:urd_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0633\u0644\u06cc\u0645\u0627\u0646 \u0635\u0648\u0628\u06c1"
     ],
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":1108784809,
-    "wof:lastmodified":1669160052,
+    "wof:lastmodified":1690938918,
     "wof:name":"Sidi Slimane",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/110/878/481/1/1108784811.geojson
+++ b/data/110/878/481/1/1108784811.geojson
@@ -48,6 +48,9 @@
     "name:cat_x_preferred":[
         "Prefectura de Sal\u00e9"
     ],
+    "name:ceb_x_preferred":[
+        "Sale"
+    ],
     "name:deu_x_preferred":[
         "Sal\u00e9"
     ],
@@ -99,6 +102,9 @@
     "name:spa_x_variant":[
         "Sal\u00e9"
     ],
+    "name:swe_x_preferred":[
+        "Sal\u00e9"
+    ],
     "name:tur_x_preferred":[
         "Sale"
     ],
@@ -138,7 +144,7 @@
         }
     ],
     "wof:id":1108784811,
-    "wof:lastmodified":1669160052,
+    "wof:lastmodified":1690938917,
     "wof:name":"Sale",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/110/878/481/3/1108784813.geojson
+++ b/data/110/878/481/3/1108784813.geojson
@@ -90,6 +90,12 @@
     "name:spa_x_preferred":[
         "Provincia de Taurirt"
     ],
+    "name:swe_x_preferred":[
+        "Taourirt"
+    ],
+    "name:tur_x_preferred":[
+        "Tavrirt"
+    ],
     "name:urd_x_preferred":[
         "\u062a\u0627\u0648\u0631\u06cc\u0631\u062a \u0635\u0648\u0628\u06c1"
     ],
@@ -132,7 +138,7 @@
         }
     ],
     "wof:id":1108784813,
-    "wof:lastmodified":1669159677,
+    "wof:lastmodified":1690938917,
     "wof:name":"Taourirt",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/110/878/481/9/1108784819.geojson
+++ b/data/110/878/481/9/1108784819.geojson
@@ -113,6 +113,12 @@
     "name:swe_x_preferred":[
         "provins Sidi Bennour"
     ],
+    "name:swe_x_variant":[
+        "Sidi Bennour"
+    ],
+    "name:tur_x_preferred":[
+        "Sidi Binnur"
+    ],
     "name:urd_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0628\u0646\u0648\u0631 \u0635\u0648\u0628\u06c1"
     ],
@@ -161,7 +167,7 @@
         }
     ],
     "wof:id":1108784819,
-    "wof:lastmodified":1669156886,
+    "wof:lastmodified":1690938917,
     "wof:name":"Sidi Bennour",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/110/878/482/1/1108784821.geojson
+++ b/data/110/878/482/1/1108784821.geojson
@@ -78,6 +78,12 @@
     "name:nan_x_preferred":[
         "Youssoufia S\u00e9ng"
     ],
+    "name:swe_x_preferred":[
+        "Youssoufia"
+    ],
+    "name:tur_x_preferred":[
+        "Yusufiye"
+    ],
     "name:urd_x_preferred":[
         "\u06cc\u0648\u0633\u0641\u06cc\u06c1 \u0635\u0648\u0628\u06c1"
     ],
@@ -120,7 +126,7 @@
         }
     ],
     "wof:id":1108784821,
-    "wof:lastmodified":1669158639,
+    "wof:lastmodified":1690938912,
     "wof:name":"Youssoufia",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/110/878/482/3/1108784823.geojson
+++ b/data/110/878/482/3/1108784823.geojson
@@ -81,6 +81,9 @@
     "name:spa_x_variant":[
         "Tarfaya"
     ],
+    "name:tur_x_preferred":[
+        "Tarfaye"
+    ],
     "name:zho_x_preferred":[
         "\u5854\u5c14\u6cd5\u4e9a\u7701"
     ],
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":1108784823,
-    "wof:lastmodified":1669158633,
+    "wof:lastmodified":1690938912,
     "wof:name":"Tarfaya",
     "wof:parent_id":1796661371,
     "wof:placetype":"county",

--- a/data/110/878/482/7/1108784827.geojson
+++ b/data/110/878/482/7/1108784827.geojson
@@ -99,6 +99,15 @@
     "name:swe_x_preferred":[
         "Azilal Province"
     ],
+    "name:swe_x_variant":[
+        "Azilal"
+    ],
+    "name:tur_x_preferred":[
+        "Ezilel"
+    ],
+    "name:uzb_x_preferred":[
+        "Azilal viloyati"
+    ],
     "name:zho_x_preferred":[
         "\u827e\u6fdf\u62c9\u52d2\u7701"
     ],
@@ -138,7 +147,7 @@
         }
     ],
     "wof:id":1108784827,
-    "wof:lastmodified":1669156509,
+    "wof:lastmodified":1690938912,
     "wof:name":"Azilal",
     "wof:parent_id":1796661357,
     "wof:placetype":"county",

--- a/data/110/878/482/9/1108784829.geojson
+++ b/data/110/878/482/9/1108784829.geojson
@@ -48,6 +48,9 @@
     "name:cat_x_preferred":[
         "Prefectura de Marr\u00e0queix"
     ],
+    "name:ceb_x_preferred":[
+        "Marrakech"
+    ],
     "name:deu_x_preferred":[
         "Marrakesch"
     ],
@@ -88,6 +91,12 @@
     "name:spa_x_preferred":[
         "Marrakech"
     ],
+    "name:swe_x_preferred":[
+        "Marrakech"
+    ],
+    "name:tur_x_preferred":[
+        "Marake\u015f"
+    ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
@@ -124,7 +133,7 @@
         }
     ],
     "wof:id":1108784829,
-    "wof:lastmodified":1669158639,
+    "wof:lastmodified":1690938912,
     "wof:name":"Marrakech",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/110/878/483/1/1108784831.geojson
+++ b/data/110/878/483/1/1108784831.geojson
@@ -96,6 +96,9 @@
     "name:swe_x_preferred":[
         "Chtouka-Ait-Baha"
     ],
+    "name:tur_x_preferred":[
+        "E\u015ftuke-Eyt Beha"
+    ],
     "name:zho_x_preferred":[
         "\u5e0c\u5716\u5361\u963f\u4f0a\u7279\u5df4\u54c8\u7701"
     ],
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":1108784831,
-    "wof:lastmodified":1669160439,
+    "wof:lastmodified":1690938915,
     "wof:name":"Chtouka Ait Baha",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/110/878/483/3/1108784833.geojson
+++ b/data/110/878/483/3/1108784833.geojson
@@ -93,6 +93,12 @@
     "name:swe_x_preferred":[
         "Settat Province"
     ],
+    "name:swe_x_variant":[
+        "Settat"
+    ],
+    "name:tur_x_preferred":[
+        "Sittat"
+    ],
     "name:zho_x_preferred":[
         "\u585e\u5854\u7279\u7701"
     ],
@@ -132,7 +138,7 @@
         }
     ],
     "wof:id":1108784833,
-    "wof:lastmodified":1669156886,
+    "wof:lastmodified":1690938915,
     "wof:name":"Settat",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/110/878/483/7/1108784837.geojson
+++ b/data/110/878/483/7/1108784837.geojson
@@ -93,6 +93,12 @@
     "name:swe_x_preferred":[
         "Meknes"
     ],
+    "name:swe_x_variant":[
+        "Mekn\u00e8s"
+    ],
+    "name:tur_x_preferred":[
+        "Meknes"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0435\u043a\u043d\u0435\u0441"
     ],
@@ -135,7 +141,7 @@
         }
     ],
     "wof:id":1108784837,
-    "wof:lastmodified":1669157824,
+    "wof:lastmodified":1690938914,
     "wof:name":"Meknes",
     "wof:parent_id":1796661365,
     "wof:placetype":"county",

--- a/data/110/878/483/9/1108784839.geojson
+++ b/data/110/878/483/9/1108784839.geojson
@@ -78,6 +78,12 @@
     "name:por_x_preferred":[
         "Tinghir"
     ],
+    "name:swe_x_preferred":[
+        "Tinghir"
+    ],
+    "name:tur_x_preferred":[
+        "Tingir"
+    ],
     "name:urd_x_preferred":[
         "\u062a\u0646\u063a\u06cc\u0631 \u0635\u0648\u0628\u06c1"
     ],
@@ -120,7 +126,7 @@
         }
     ],
     "wof:id":1108784839,
-    "wof:lastmodified":1669157463,
+    "wof:lastmodified":1690938914,
     "wof:name":"Tinghir",
     "wof:parent_id":1796661363,
     "wof:placetype":"county",

--- a/data/110/878/484/1/1108784841.geojson
+++ b/data/110/878/484/1/1108784841.geojson
@@ -87,6 +87,12 @@
     "name:spa_x_preferred":[
         "Provincia de Sidi Ifni"
     ],
+    "name:swe_x_preferred":[
+        "Sidi Ifni"
+    ],
+    "name:tur_x_preferred":[
+        "Sidi \u0130fni"
+    ],
     "name:zho_x_preferred":[
         "\u897f\u8fea\u4f0a\u592b\u5c3c\u7701"
     ],
@@ -126,7 +132,7 @@
         }
     ],
     "wof:id":1108784841,
-    "wof:lastmodified":1669158473,
+    "wof:lastmodified":1690938915,
     "wof:name":"Sidi Ifni",
     "wof:parent_id":1796661367,
     "wof:placetype":"county",

--- a/data/110/878/484/3/1108784843.geojson
+++ b/data/110/878/484/3/1108784843.geojson
@@ -102,6 +102,12 @@
     "name:spa_x_preferred":[
         "Provincia de Uarzazate"
     ],
+    "name:swe_x_preferred":[
+        "Ouarzazate"
+    ],
+    "name:tur_x_preferred":[
+        "Varzazat"
+    ],
     "name:zho_x_preferred":[
         "\u74e6\u723e\u624e\u624e\u7279\u7701"
     ],
@@ -141,7 +147,7 @@
         }
     ],
     "wof:id":1108784843,
-    "wof:lastmodified":1669157462,
+    "wof:lastmodified":1690938915,
     "wof:name":"Ouarzazate",
     "wof:parent_id":1796661363,
     "wof:placetype":"county",

--- a/data/112/577/009/5/1125770095.geojson
+++ b/data/112/577/009/5/1125770095.geojson
@@ -40,6 +40,9 @@
     "name:ceb_x_preferred":[
         "Khouribga"
     ],
+    "name:ces_x_preferred":[
+        "Ch\u00faribga"
+    ],
     "name:cym_x_preferred":[
         "Khouribga"
     ],
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":1125770095,
-    "wof:lastmodified":1669156882,
+    "wof:lastmodified":1690939112,
     "wof:name":"Khouribga",
     "wof:parent_id":890422519,
     "wof:placetype":"locality",

--- a/data/112/577/009/9/1125770099.geojson
+++ b/data/112/577/009/9/1125770099.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0642\u0646\u064a\u0637\u0631\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Kenitra"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0646\u06cc\u0637\u0631\u0647"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:ben_x_preferred":[
         "\u0995\u09c7\u09a8\u09bf\u09a4\u09cd\u09b0\u09be"
+    ],
+    "name:bul_x_preferred":[
+        "\u041a\u0435\u043d\u0438\u0442\u0440\u0430"
     ],
     "name:cat_x_preferred":[
         "Kenitra"
@@ -289,7 +295,7 @@
         }
     ],
     "wof:id":1125770099,
-    "wof:lastmodified":1669160428,
+    "wof:lastmodified":1690939112,
     "wof:name":"Kenitra",
     "wof:parent_id":890427533,
     "wof:placetype":"locality",

--- a/data/112/577/634/5/1125776345.geojson
+++ b/data/112/577/634/5/1125776345.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u062c\u0631\u0633\u064a\u0641"
     ],
+    "name:ast_x_preferred":[
+        "Guercif"
+    ],
     "name:azb_x_preferred":[
         "\u062c\u0631\u0633\u06cc\u0641"
     ],
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":1125776345,
-    "wof:lastmodified":1669160045,
+    "wof:lastmodified":1690939111,
     "wof:name":"Guercif",
     "wof:parent_id":1108784807,
     "wof:placetype":"locality",

--- a/data/112/578/418/7/1125784187.geojson
+++ b/data/112/578/418/7/1125784187.geojson
@@ -52,6 +52,9 @@
     "name:ceb_x_preferred":[
         "Ksar el Kebir"
     ],
+    "name:ces_x_preferred":[
+        "Ksar Al Kebir"
+    ],
     "name:dan_x_preferred":[
         "Ksar el-K\u00e9bir"
     ],
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":1125784187,
-    "wof:lastmodified":1669161794,
+    "wof:lastmodified":1690939111,
     "wof:name":"Ksar el Kebir",
     "wof:parent_id":890422513,
     "wof:placetype":"locality",

--- a/data/112/585/154/9/1125851549.geojson
+++ b/data/112/585/154/9/1125851549.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0628\u0646\u0649 \u0645\u0644\u0627\u0644"
     ],
+    "name:ast_x_preferred":[
+        "Beni Mellal"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646\u06cc\u200c\u0645\u0644\u0627\u0644"
     ],
@@ -41,6 +44,9 @@
         "Beni Mellal"
     ],
     "name:ceb_x_preferred":[
+        "Beni Mellal"
+    ],
+    "name:ces_x_preferred":[
         "Beni Mellal"
     ],
     "name:cym_x_preferred":[
@@ -226,7 +232,7 @@
         }
     ],
     "wof:id":1125851549,
-    "wof:lastmodified":1669156882,
+    "wof:lastmodified":1690939111,
     "wof:name":"Beni Mellal",
     "wof:parent_id":890452779,
     "wof:placetype":"locality",

--- a/data/112/589/332/9/1125893329.geojson
+++ b/data/112/589/332/9/1125893329.geojson
@@ -33,6 +33,9 @@
     "name:ary_x_preferred":[
         "\u0644\u0641\u0642\u064a\u0647 \u0628\u0646\u0635\u0627\u0644\u062d"
     ],
+    "name:ast_x_preferred":[
+        "Fkih Ben Saleh"
+    ],
     "name:azb_x_preferred":[
         "\u0641\u0642\u06cc\u0647 \u0628\u0646 \u0635\u0627\u0644\u062d"
     ],
@@ -87,6 +90,9 @@
     "name:und_x_variant":[
         "Al Fqih Ben \u00c7alah"
     ],
+    "name:uzb_x_preferred":[
+        "Fquih Ben Salah"
+    ],
     "name:zho_x_preferred":[
         "\u5f17\u57fa\u8d6b\u62dc\u5c3c\u585e\u62c9\u8d6b"
     ],
@@ -137,7 +143,7 @@
         }
     ],
     "wof:id":1125893329,
-    "wof:lastmodified":1669156882,
+    "wof:lastmodified":1690939110,
     "wof:name":"Fkih Ben Salah",
     "wof:parent_id":1108784787,
     "wof:placetype":"locality",

--- a/data/112/597/828/7/1125978287.geojson
+++ b/data/112/597/828/7/1125978287.geojson
@@ -58,6 +58,9 @@
     "name:swe_x_preferred":[
         "Boujniba"
     ],
+    "name:uzb_x_preferred":[
+        "Boujniba"
+    ],
     "qs_pg:aaroncc":"MA",
     "qs_pg:gn_country":"MA",
     "qs_pg:gn_fcode":"PPL",
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":1125978287,
-    "wof:lastmodified":1669156882,
+    "wof:lastmodified":1690939110,
     "wof:name":"Boujniba",
     "wof:parent_id":890422519,
     "wof:placetype":"locality",

--- a/data/112/598/839/5/1125988395.geojson
+++ b/data/112/598/839/5/1125988395.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u0628\u0631\u0634\u064a\u062f"
     ],
+    "name:ast_x_preferred":[
+        "Berrechid"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u0634\u06cc\u062f"
     ],
@@ -83,6 +86,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d9\u30ec\u30c1\u30c9"
+    ],
+    "name:jpn_x_variant":[
+        "\u30d9\u30ec\u30b7\u30c9"
     ],
     "name:kan_x_preferred":[
         "\u0cac\u0cb0\u0ccd\u0cb0\u0cc6\u0c9a\u0cbf\u0ca1\u0ccd"
@@ -215,7 +221,7 @@
         }
     ],
     "wof:id":1125988395,
-    "wof:lastmodified":1669157453,
+    "wof:lastmodified":1690939111,
     "wof:name":"Berrechid",
     "wof:parent_id":1108784793,
     "wof:placetype":"locality",

--- a/data/114/190/887/1/1141908871.geojson
+++ b/data/114/190/887/1/1141908871.geojson
@@ -36,6 +36,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0643\u0627\u062f\u064a\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Agadir"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u06a9\u0627\u062f\u06cc\u0631"
     ],
@@ -478,7 +481,7 @@
         }
     ],
     "wof:id":1141908871,
-    "wof:lastmodified":1669163888,
+    "wof:lastmodified":1690939122,
     "wof:name":"Agadir",
     "wof:parent_id":890429099,
     "wof:placetype":"locality",

--- a/data/114/190/890/1/1141908901.geojson
+++ b/data/114/190/890/1/1141908901.geojson
@@ -26,6 +26,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0633\u0645\u0627\u0631\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Smara"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0645\u0627\u0631\u0647"
     ],
@@ -115,6 +118,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0938\u094d\u092e\u093e\u0930\u093e"
+    ],
+    "name:mlt_x_preferred":[
+        "Smara"
     ],
     "name:msa_x_preferred":[
         "Smara"
@@ -297,7 +303,7 @@
         }
     ],
     "wof:id":1141908901,
-    "wof:lastmodified":1669158636,
+    "wof:lastmodified":1690939122,
     "wof:name":"Smara",
     "wof:parent_id":1796661371,
     "wof:placetype":"locality",

--- a/data/132/701/461/9/1327014619.geojson
+++ b/data/132/701/461/9/1327014619.geojson
@@ -44,6 +44,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0631\u0634\u064a\u062f\u064a\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Errachidia"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0634\u06cc\u062f\u06cc\u0647"
     ],
@@ -116,6 +119,9 @@
     "name:lit_x_variant":[
         "Er Ra\u0161idija"
     ],
+    "name:msa_x_preferred":[
+        "Errachidia"
+    ],
     "name:nld_x_preferred":[
         "Errachidia"
     ],
@@ -152,6 +158,9 @@
     "name:tur_x_preferred":[
         "Er Rachidia"
     ],
+    "name:tur_x_variant":[
+        "Er-Ra\u015fidiye"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u0440-\u0420\u0430\u0448\u0438\u0434\u0456\u044f"
     ],
@@ -160,6 +169,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0627\u0644\u0631\u0634\u06cc\u062f\u06cc\u06c1"
+    ],
+    "name:uzb_x_preferred":[
+        "Erraxidiya"
     ],
     "name:vie_x_preferred":[
         "Er Rachidia"
@@ -301,7 +313,7 @@
         }
     ],
     "wof:id":1327014619,
-    "wof:lastmodified":1669157636,
+    "wof:lastmodified":1690938895,
     "wof:name":"Errachidia",
     "wof:parent_id":1108784773,
     "wof:placetype":"locality",

--- a/data/179/666/135/7/1796661357.geojson
+++ b/data/179/666/135/7/1796661357.geojson
@@ -27,6 +27,9 @@
     "name:cat_x_preferred":[
         "B\u00e9ni Mellal-Kh\u00e9nifra"
     ],
+    "name:ces_x_preferred":[
+        "B\u00e9ni Mellal-Kh\u00e9nifra"
+    ],
     "name:dan_x_preferred":[
         "B\u00e9ni Mellal-Kh\u00e9nifra"
     ],
@@ -39,6 +42,9 @@
     "name:fas_x_preferred":[
         "\u0628\u0646\u06cc \u0645\u0644\u0627\u0644 \u062e\u0646\u06cc\u0641\u0631\u0647"
     ],
+    "name:fin_x_preferred":[
+        "B\u00e9ni Mellal-Kh\u00e9nifra"
+    ],
     "name:fra_x_preferred":[
         "B\u00e9ni Mellal-Kh\u00e9nifra"
     ],
@@ -46,6 +52,9 @@
         "B\u00e9ni Mellal-Kh\u00e9nifra"
     ],
     "name:glg_x_preferred":[
+        "B\u00e9ni Mellal-Kh\u00e9nifra"
+    ],
+    "name:ind_x_preferred":[
         "B\u00e9ni Mellal-Kh\u00e9nifra"
     ],
     "name:ita_x_preferred":[
@@ -56,6 +65,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubca0\ub2c8\uba5c\ub784\ucf00\ub2c8\ud504\ub77c \uc9c0\ubc29"
+    ],
+    "name:msa_x_preferred":[
+        "B\u00e9ni Mellal-Kh\u00e9nifra"
     ],
     "name:nan_x_preferred":[
         "B\u00e9ni Mellal-Kh\u00e9nifra T\u0113-hng"
@@ -107,7 +119,7 @@
         }
     ],
     "wof:id":1796661357,
-    "wof:lastmodified":1669156885,
+    "wof:lastmodified":1690939115,
     "wof:name":"B\u00e9ni Mellal-Kh\u00e9nifra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/135/9/1796661359.geojson
+++ b/data/179/666/135/9/1796661359.geojson
@@ -21,6 +21,9 @@
     "name:cat_x_preferred":[
         "Casablanca-Settat"
     ],
+    "name:ces_x_preferred":[
+        "Casablanca-Settat"
+    ],
     "name:dan_x_preferred":[
         "Casablanca-Settat"
     ],
@@ -33,6 +36,9 @@
     "name:fas_x_preferred":[
         "\u06a9\u0627\u0632\u0627\u0628\u0644\u0627\u0646\u06a9\u0627 \u0633\u0637\u0627\u062a"
     ],
+    "name:fin_x_preferred":[
+        "Casablanca-Settat"
+    ],
     "name:fra_x_preferred":[
         "Casablanca-Settat"
     ],
@@ -41,6 +47,9 @@
     ],
     "name:hye_x_preferred":[
         "\u053f\u0561\u057d\u0561\u0562\u056c\u0561\u0576\u056f\u0561 \u054d\u0565\u057f\u0561\u057f"
+    ],
+    "name:ind_x_preferred":[
+        "Casablanca-Settat"
     ],
     "name:ita_x_preferred":[
         "Casablanca-Settat"
@@ -54,6 +63,9 @@
     "name:mlt_x_preferred":[
         "Casablanca-Settat"
     ],
+    "name:msa_x_preferred":[
+        "Casablanca-Settat"
+    ],
     "name:nan_x_preferred":[
         "Casablanca-Settat T\u0113-hng"
     ],
@@ -61,6 +73,9 @@
         "Casablanca-Sattat"
     ],
     "name:por_x_preferred":[
+        "Casablanca-Settat"
+    ],
+    "name:slk_x_preferred":[
         "Casablanca-Settat"
     ],
     "name:spa_x_preferred":[
@@ -95,7 +110,7 @@
         }
     ],
     "wof:id":1796661359,
-    "wof:lastmodified":1669157457,
+    "wof:lastmodified":1690939115,
     "wof:name":"Casablanca-Settat",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/1/1796661361.geojson
+++ b/data/179/666/136/1/1796661361.geojson
@@ -39,10 +39,16 @@
     "name:fas_x_preferred":[
         "\u062f\u0627\u062e\u0644\u0647 \u0648\u0627\u062f\u06cc \u0627\u0644\u0630\u0647\u0628"
     ],
+    "name:fin_x_preferred":[
+        "Dakhla-Oued Ed-Dahab"
+    ],
     "name:fra_x_preferred":[
         "Dakhla-Oued Ed Dahab"
     ],
     "name:frr_x_preferred":[
+        "Dakhla-Oued Ed-Dahab"
+    ],
+    "name:ind_x_preferred":[
         "Dakhla-Oued Ed-Dahab"
     ],
     "name:ita_x_preferred":[
@@ -53,6 +59,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub2e4\ud074\ub77c\uc6e8\ub4dc\uc5d0\ub4dc\ub2e4\ud558\ube0c \uc9c0\ubc29"
+    ],
+    "name:msa_x_preferred":[
+        "Dakhla-Oued Ed-Dahab"
     ],
     "name:nan_x_preferred":[
         "Dakhla-Oued Ed-Dahab T\u0113-hng"
@@ -65,6 +74,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0414\u0430\u0445\u043b\u0430-\u0423\u044d\u0434-\u042d\u0434-\u0414\u0430\u0445\u0430\u0431"
+    ],
+    "name:swe_x_preferred":[
+        "Dakhla-Oued Ed-Dahab"
     ],
     "name:tur_x_preferred":[
         "Dahla-Vadi Ed-Dahab"
@@ -101,7 +113,7 @@
         }
     ],
     "wof:id":1796661361,
-    "wof:lastmodified":1669157461,
+    "wof:lastmodified":1690939115,
     "wof:name":"Dakhla-Oued Ed-Dahab",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/3/1796661363.geojson
+++ b/data/179/666/136/3/1796661363.geojson
@@ -33,10 +33,16 @@
     "name:fas_x_preferred":[
         "\u062f\u0631\u0639\u0647 \u062a\u0627\u0641\u06cc\u0644\u0627\u0644\u062a"
     ],
+    "name:fin_x_preferred":[
+        "Dr\u00e2a-Tafilalet"
+    ],
     "name:fra_x_preferred":[
         "Dr\u00e2a-Tafilalet"
     ],
     "name:frr_x_preferred":[
+        "Dr\u00e2a-Tafilalet"
+    ],
+    "name:ind_x_preferred":[
         "Dr\u00e2a-Tafilalet"
     ],
     "name:ita_x_preferred":[
@@ -47,6 +53,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub4dc\ub77c\ud0c0\ud544\ub784\ub808\ud2b8 \uc9c0\ubc29"
+    ],
+    "name:msa_x_preferred":[
+        "Dr\u00e2a-Tafilalet"
     ],
     "name:nan_x_preferred":[
         "Dr\u00e2a-Tafilalet T\u0113-hng"
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":1796661363,
-    "wof:lastmodified":1669157821,
+    "wof:lastmodified":1690939116,
     "wof:name":"Dr\u00e2a-Tafilalet",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/5/1796661365.geojson
+++ b/data/179/666/136/5/1796661365.geojson
@@ -36,10 +36,16 @@
     "name:fas_x_preferred":[
         "\u0641\u0627\u0633 \u0645\u06a9\u0646\u0627\u0633"
     ],
+    "name:fin_x_preferred":[
+        "F\u00e8s-Mekn\u00e8s"
+    ],
     "name:fra_x_preferred":[
         "F\u00e8s-Mekn\u00e8s"
     ],
     "name:frr_x_preferred":[
+        "F\u00e8s-Mekn\u00e8s"
+    ],
+    "name:ind_x_preferred":[
         "F\u00e8s-Mekn\u00e8s"
     ],
     "name:ita_x_preferred":[
@@ -50,6 +56,12 @@
     ],
     "name:kor_x_preferred":[
         "\ud398\uc2a4\uba54\ud06c\ub124\uc2a4 \uc9c0\ubc29"
+    ],
+    "name:mlt_x_preferred":[
+        "F\u00e8s-Mekn\u00e8s"
+    ],
+    "name:msa_x_preferred":[
+        "F\u00e8s-Mekn\u00e8s"
     ],
     "name:nan_x_preferred":[
         "F\u00e8s-Mekn\u00e8s T\u0113-hng"
@@ -101,7 +113,7 @@
         }
     ],
     "wof:id":1796661365,
-    "wof:lastmodified":1669158472,
+    "wof:lastmodified":1690939116,
     "wof:name":"F\u00e8s-Mekn\u00e8s",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/7/1796661367.geojson
+++ b/data/179/666/136/7/1796661367.geojson
@@ -39,6 +39,9 @@
     "name:fas_x_preferred":[
         "\u06a9\u0644\u0645\u06cc\u0645 \u0648\u0627\u062f \u0646\u0648\u0646"
     ],
+    "name:fin_x_preferred":[
+        "Guelmim-Oued Noun"
+    ],
     "name:fra_x_preferred":[
         "Guelmim-Oued Noun"
     ],
@@ -47,6 +50,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05d2\u05d5\u05d0\u05dc\u05de\u05d9\u05dd-\u05d0\u05d5\u05d4\u05d3 \u05e0\u05d5\u05df"
+    ],
+    "name:ind_x_preferred":[
+        "Guelmim-Oued Noun"
     ],
     "name:ita_x_preferred":[
         "Guelmim-Oued Noun"
@@ -57,8 +63,14 @@
     "name:kor_x_preferred":[
         "\uac94\ubc08\uc6e8\ub4dc\ub208 \uc9c0\ubc29"
     ],
+    "name:msa_x_preferred":[
+        "Guelmim-Oued Noun"
+    ],
     "name:nan_x_preferred":[
         "Guelmim-Oued Noun T\u0113-hng"
+    ],
+    "name:nld_x_preferred":[
+        "N\u00fbl Lamta"
     ],
     "name:pol_x_preferred":[
         "Kulmim-Wad Nun"
@@ -71,6 +83,9 @@
     ],
     "name:spa_x_preferred":[
         "Guelmim-R\u00edo Noun"
+    ],
+    "name:spa_x_variant":[
+        "Guelmim-R\u00edo Nun"
     ],
     "name:tur_x_preferred":[
         "Gulmim-Vadi Nun"
@@ -107,7 +122,7 @@
         }
     ],
     "wof:id":1796661367,
-    "wof:lastmodified":1669158631,
+    "wof:lastmodified":1690939115,
     "wof:name":"Guelmim-Oued Noun",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/1/1796661371.geojson
+++ b/data/179/666/137/1/1796661371.geojson
@@ -39,10 +39,16 @@
     "name:fas_x_preferred":[
         "\u0627\u0644\u0639\u06cc\u0648\u0646 \u0633\u0627\u0642\u06cc\u0647 \u0627\u0644\u062d\u0645\u0631\u0627"
     ],
+    "name:fin_x_preferred":[
+        "La\u00e2youne-Sakia El Hamra"
+    ],
     "name:fra_x_preferred":[
         "La\u00e2youne-Sakia El Hamra"
     ],
     "name:frr_x_preferred":[
+        "La\u00e2youne-Sakia El Hamra"
+    ],
+    "name:ind_x_preferred":[
         "La\u00e2youne-Sakia El Hamra"
     ],
     "name:ita_x_preferred":[
@@ -53,6 +59,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub77c\uc724\uc0ac\ud0a4\uc544\uc5d8\ud568\ub77c \uc9c0\ubc29"
+    ],
+    "name:msa_x_preferred":[
+        "La\u00e2youne-Sakia El Hamra"
     ],
     "name:nan_x_preferred":[
         "La\u00e2youne-Sakia El Hamra T\u0113-hng"
@@ -110,7 +119,7 @@
         }
     ],
     "wof:id":1796661371,
-    "wof:lastmodified":1669158637,
+    "wof:lastmodified":1690939117,
     "wof:name":"La\u00e2youne-Sakia El Hamra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/3/1796661373.geojson
+++ b/data/179/666/137/3/1796661373.geojson
@@ -45,6 +45,9 @@
     "name:hin_x_preferred":[
         "\u092e\u0930\u093e\u0915\u0947\u0936-\u0938\u092b\u093c\u0940"
     ],
+    "name:ind_x_preferred":[
+        "Marrakesh-Safi"
+    ],
     "name:ita_x_preferred":[
         "Marrakech-Safi"
     ],
@@ -56,6 +59,12 @@
     ],
     "name:kor_x_preferred":[
         "\ub9c8\ub77c\ucf00\uc2dc\uc0ac\ud53c \uc9c0\ubc29"
+    ],
+    "name:mlt_x_preferred":[
+        "Marrakesh-Safi"
+    ],
+    "name:msa_x_preferred":[
+        "Marrakesh-Safi"
     ],
     "name:nan_x_preferred":[
         "Marrakesh-Safi T\u0113-hng"
@@ -110,7 +119,7 @@
         }
     ],
     "wof:id":1796661373,
-    "wof:lastmodified":1669159674,
+    "wof:lastmodified":1690939117,
     "wof:name":"Marrakesh-Safi",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/5/1796661375.geojson
+++ b/data/179/666/137/5/1796661375.geojson
@@ -42,6 +42,9 @@
     "name:fas_x_preferred":[
         "\u0645\u0646\u0637\u0642\u0647 \u0634\u0631\u0642"
     ],
+    "name:fin_x_preferred":[
+        "Oriental"
+    ],
     "name:fra_x_preferred":[
         "Oriental"
     ],
@@ -54,6 +57,9 @@
     "name:heb_x_preferred":[
         "\u05d0\u05d5\u05e8\u05d9\u05d9\u05e0\u05d8\u05dc"
     ],
+    "name:ind_x_preferred":[
+        "Oriental"
+    ],
     "name:ita_x_preferred":[
         "Regione Orientale"
     ],
@@ -65,6 +71,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc624\ub9ac\uc559\ud0c8 \uc9c0\ubc29"
+    ],
+    "name:msa_x_preferred":[
+        "Oriental"
     ],
     "name:nan_x_preferred":[
         "Oriental T\u0113-hng"
@@ -119,7 +128,7 @@
         }
     ],
     "wof:id":1796661375,
-    "wof:lastmodified":1669160049,
+    "wof:lastmodified":1690939118,
     "wof:name":"Oriental",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/7/1796661377.geojson
+++ b/data/179/666/137/7/1796661377.geojson
@@ -21,6 +21,9 @@
     "name:cat_x_preferred":[
         "Rabat-Sal\u00e9-Kenitra"
     ],
+    "name:ces_x_preferred":[
+        "Rabat-Sal\u00e9-K\u00e9nitra"
+    ],
     "name:dan_x_preferred":[
         "Rabat-Sal\u00e9-K\u00e9nitra"
     ],
@@ -30,10 +33,16 @@
     "name:eng_x_preferred":[
         "Rabat-Sal\u00e9-K\u00e9nitra"
     ],
+    "name:fin_x_preferred":[
+        "Rabat-Sal\u00e9-K\u00e9nitra"
+    ],
     "name:fra_x_preferred":[
         "Rabat-Sal\u00e9-K\u00e9nitra"
     ],
     "name:frr_x_preferred":[
+        "Rabat-Sal\u00e9-K\u00e9nitra"
+    ],
+    "name:ind_x_preferred":[
         "Rabat-Sal\u00e9-K\u00e9nitra"
     ],
     "name:ita_x_preferred":[
@@ -44,6 +53,12 @@
     ],
     "name:kor_x_preferred":[
         "\ub77c\ubc14\ud2b8\uc0b4\ub808\ucf00\ub2c8\ud2b8\ub77c \uc9c0\ubc29"
+    ],
+    "name:mlt_x_preferred":[
+        "Rabat-Sal\u00e9-K\u00e9nitra"
+    ],
+    "name:msa_x_preferred":[
+        "Rabat-Sal\u00e9-K\u00e9nitra"
     ],
     "name:nan_x_preferred":[
         "Rabat-Sal\u00e9-K\u00e9nitra T\u0113-hng"
@@ -92,7 +107,7 @@
         }
     ],
     "wof:id":1796661377,
-    "wof:lastmodified":1669160437,
+    "wof:lastmodified":1690939117,
     "wof:name":"Rabat-Sal\u00e9-K\u00e9nitra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/9/1796661379.geojson
+++ b/data/179/666/137/9/1796661379.geojson
@@ -21,6 +21,9 @@
     "name:cat_x_preferred":[
         "Souss-Massa"
     ],
+    "name:ces_x_preferred":[
+        "S\u00fas-M\u00e1ssa"
+    ],
     "name:dan_x_preferred":[
         "Souss-Massa"
     ],
@@ -36,10 +39,16 @@
     "name:fas_x_preferred":[
         "\u0633\u0648\u0633 \u0645\u0627\u0633\u0647"
     ],
+    "name:fin_x_preferred":[
+        "Souss-Massa"
+    ],
     "name:fra_x_preferred":[
         "Souss-Massa"
     ],
     "name:frr_x_preferred":[
+        "Souss-Massa"
+    ],
+    "name:ind_x_preferred":[
         "Souss-Massa"
     ],
     "name:ita_x_preferred":[
@@ -53,6 +62,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc218\uc2a4\ub9c8\uc0ac \uc9c0\ubc29"
+    ],
+    "name:msa_x_preferred":[
+        "Souss-Massa"
     ],
     "name:nan_x_preferred":[
         "Souss-Massa T\u0113-hng"
@@ -101,7 +113,7 @@
         }
     ],
     "wof:id":1796661379,
-    "wof:lastmodified":1669161172,
+    "wof:lastmodified":1690939117,
     "wof:name":"Souss-Massa",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/138/1/1796661381.geojson
+++ b/data/179/666/138/1/1796661381.geojson
@@ -37,16 +37,23 @@
         "Tanger-Tetouan-Al Hoceima"
     ],
     "name:eng_x_variant":[
-        "Tanger-T\u00e9touan-Al Hoce\u00efma"
+        "Tanger-T\u00e9touan-Al Hoce\u00efma",
+        "Tangier-Tetouan-Al Hoceima"
     ],
     "name:fas_x_preferred":[
         "\u0637\u0646\u062c\u0647 \u062a\u0637\u0648\u0627\u0646 \u0627\u0644\u062d\u0633\u06cc\u0645\u0647"
+    ],
+    "name:fin_x_preferred":[
+        "Tanger-Tetouan-Al Hoceima"
     ],
     "name:fra_x_preferred":[
         "Tanger-T\u00e9touan-Al Hoce\u00efma"
     ],
     "name:frr_x_preferred":[
         "Tanger-T\u00e9touan-Al Hoce\u00efma"
+    ],
+    "name:ind_x_preferred":[
+        "Tanger-Tetouan-Al Hoceima"
     ],
     "name:ita_x_preferred":[
         "Tangeri-Tetouan-Al Hoceima"
@@ -56,6 +63,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud0d5\ud5e4\ub974\ud14c\ud22c\uc548\uc54c\ud638\uc138\uc774\ub9c8 \uc9c0\ubc29"
+    ],
+    "name:msa_x_preferred":[
+        "Tanger-Tetouan-Al Hoceima"
     ],
     "name:nan_x_preferred":[
         "Tanger-Tetouan-Al Hoceima T\u0113-hng"
@@ -104,7 +114,7 @@
         }
     ],
     "wof:id":1796661381,
-    "wof:lastmodified":1669161799,
+    "wof:lastmodified":1690939116,
     "wof:name":"Tanger-Tetouan-Al Hoceima",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/421/166/481/421166481.geojson
+++ b/data/421/166/481/421166481.geojson
@@ -18,8 +18,14 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:afr_x_preferred":[
+        "Ait Aatab"
+    ],
     "name:ara_x_preferred":[
         "\u0627\u064a\u062a \u0639\u062a\u0627\u0628"
+    ],
+    "name:arg_x_preferred":[
+        "Ait Aatab"
     ],
     "name:ary_x_preferred":[
         "\u0627\u064a\u062a \u0639\u062a\u0627\u0628"
@@ -27,8 +33,32 @@
     "name:arz_x_preferred":[
         "\u0627\u064a\u062a \u0639\u062a\u0627\u0628"
     ],
+    "name:ast_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:bam_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:bar_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:bre_x_preferred":[
+        "Ait Aatab"
+    ],
     "name:cat_x_preferred":[
         "Ait Attab"
+    ],
+    "name:ces_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:cos_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:cym_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:dan_x_preferred":[
+        "Ait Aatab"
     ],
     "name:deu_x_preferred":[
         "A\u00eft Attab"
@@ -36,14 +66,209 @@
     "name:eng_x_preferred":[
         "Ait Attab"
     ],
+    "name:epo_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:est_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:eus_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:fin_x_preferred":[
+        "Ait Aatab"
+    ],
     "name:fra_x_preferred":[
         "A\u00eft A\u00e2tab"
+    ],
+    "name:frc_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:frp_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:fur_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:gla_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:gle_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:glg_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:gsw_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:hrv_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:hun_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:ido_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:ile_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:ina_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:ind_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:ita_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:jam_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:kab_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:kon_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:lij_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:lim_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:lit_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:ltz_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:min_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:mlg_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:mri_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:msa_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:nap_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:nds_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:nld_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:nno_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:nob_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:nrm_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:oci_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:pap_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:pcd_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:pms_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:pol_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:por_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:prg_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:rgn_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:roh_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:ron_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:scn_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:sco_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:shi_x_preferred":[
+        "\u025bin \u025btab"
+    ],
+    "name:slk_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:slv_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:spa_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:sqi_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:srd_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:swa_x_preferred":[
+        "Ait Aatab"
     ],
     "name:swe_x_preferred":[
         "A\u00eft Attab"
     ],
+    "name:tur_x_preferred":[
+        "Ait Aatab"
+    ],
     "name:und_x_variant":[
         "Ayt Tab"
+    ],
+    "name:uzb_x_preferred":[
+        "Ait Attab"
+    ],
+    "name:vec_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:vie_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:vls_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:vmf_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:vol_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:wln_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:wol_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:yor_x_preferred":[
+        "Ait Aatab"
+    ],
+    "name:zul_x_preferred":[
+        "Ait Aatab"
     ],
     "qs:gn_country":"MA",
     "qs:gn_fcode":"PPL",
@@ -100,7 +325,7 @@
         }
     ],
     "wof:id":421166481,
-    "wof:lastmodified":1669161800,
+    "wof:lastmodified":1690938923,
     "wof:name":"Ait Attab",
     "wof:parent_id":1108784827,
     "wof:placetype":"locality",

--- a/data/421/168/375/421168375.geojson
+++ b/data/421/168/375/421168375.geojson
@@ -42,6 +42,9 @@
     "name:bul_x_preferred":[
         "\u0410\u0441\u0438\u043b\u0430\u0445"
     ],
+    "name:bul_x_variant":[
+        "\u0410\u0441\u0438\u043b\u0430"
+    ],
     "name:cat_x_preferred":[
         "Asilah"
     ],
@@ -239,7 +242,7 @@
         }
     ],
     "wof:id":421168375,
-    "wof:lastmodified":1669161803,
+    "wof:lastmodified":1690938923,
     "wof:name":"\u0627\u0635\u064a\u0644\u0629",
     "wof:parent_id":1108784783,
     "wof:placetype":"locality",

--- a/data/421/170/487/421170487.geojson
+++ b/data/421/170/487/421170487.geojson
@@ -156,6 +156,9 @@
     "name:mar_x_preferred":[
         "\u090f\u0938\u093e\u0909\u0907\u0930\u093e"
     ],
+    "name:mlt_x_preferred":[
+        "Essaouira"
+    ],
     "name:msa_x_preferred":[
         "Essaouira"
     ],
@@ -311,7 +314,7 @@
         }
     ],
     "wof:id":421170487,
-    "wof:lastmodified":1669161806,
+    "wof:lastmodified":1690938939,
     "wof:name":"Essaouira",
     "wof:parent_id":890453939,
     "wof:placetype":"locality",

--- a/data/421/172/677/421172677.geojson
+++ b/data/421/172/677/421172677.geojson
@@ -28,6 +28,9 @@
     "name:ceb_x_preferred":[
         "A\u00efn Harrouda"
     ],
+    "name:ceb_x_variant":[
+        "Ain Harrouda"
+    ],
     "name:eng_x_preferred":[
         "A\u00efn Harrouda"
     ],
@@ -72,10 +75,10 @@
     "qs:woe_id":1529939,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
+        1796661359,
         102191573,
         85632693,
-        890424147,
-        1796661359
+        890424147
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421172677,
-    "wof:lastmodified":1669161807,
+    "wof:lastmodified":1690938929,
     "wof:name":"\u0639\u064a\u0646 \u062d\u0631\u0648\u062f\u0629",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/173/193/421173193.geojson
+++ b/data/421/173/193/421173193.geojson
@@ -21,6 +21,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0643\u0627\u064a\u0645\u062f\u0646"
     ],
+    "name:ary_x_preferred":[
+        "\u0624\u0643\u0627\u064a\u0645\u062f\u0646"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u0648\u0643\u0627\u064a\u0645\u062f\u0646"
     ],
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421173193,
-    "wof:lastmodified":1669161808,
+    "wof:lastmodified":1690938929,
     "wof:name":"Oukaimedene",
     "wof:parent_id":1108784801,
     "wof:placetype":"locality",

--- a/data/421/174/109/421174109.geojson
+++ b/data/421/174/109/421174109.geojson
@@ -93,6 +93,9 @@
     "name:swe_x_preferred":[
         "Beni Enzar"
     ],
+    "name:swe_x_variant":[
+        "Bni Ansar"
+    ],
     "name:und_x_variant":[
         "Beni Anzar"
     ],
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421174109,
-    "wof:lastmodified":1669161809,
+    "wof:lastmodified":1690938928,
     "wof:name":"Beni Enzar",
     "wof:parent_id":890455271,
     "wof:placetype":"locality",

--- a/data/421/174/111/421174111.geojson
+++ b/data/421/174/111/421174111.geojson
@@ -24,6 +24,9 @@
     "name:ary_x_preferred":[
         "\u0628\u064a\u0648\u06af\u0631\u0649"
     ],
+    "name:ary_x_variant":[
+        "\u0628\u064a\u0648\u0763\u0631\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u06cc\u0648\u06a9\u0631\u0647"
     ],
@@ -65,6 +68,9 @@
     ],
     "name:shi_x_preferred":[
         "Big\u02b7ra"
+    ],
+    "name:spa_x_preferred":[
+        "Biougra"
     ],
     "name:swe_x_preferred":[
         "Biougra"
@@ -132,7 +138,7 @@
         }
     ],
     "wof:id":421174111,
-    "wof:lastmodified":1669161809,
+    "wof:lastmodified":1690938927,
     "wof:name":"Biougra",
     "wof:parent_id":1108784831,
     "wof:placetype":"locality",

--- a/data/421/174/113/421174113.geojson
+++ b/data/421/174/113/421174113.geojson
@@ -63,6 +63,9 @@
     "name:swe_x_preferred":[
         "Saidia"
     ],
+    "name:swe_x_variant":[
+        "Sa\u00efdia"
+    ],
     "name:und_x_variant":[
         "Sa\u00efda"
     ],
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421174113,
-    "wof:lastmodified":1669161810,
+    "wof:lastmodified":1690938928,
     "wof:name":"\u0627\u0644\u0633\u0639\u064a\u062f\u064a\u0629",
     "wof:parent_id":1108784771,
     "wof:placetype":"locality",

--- a/data/421/175/995/421175995.geojson
+++ b/data/421/175/995/421175995.geojson
@@ -27,6 +27,9 @@
     "name:arz_x_preferred":[
         "\u0632\u0627\u064a\u0648"
     ],
+    "name:ast_x_preferred":[
+        "Zaio"
+    ],
     "name:azb_x_preferred":[
         "\u0632\u0627\u06cc\u0648"
     ],
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421175995,
-    "wof:lastmodified":1669161811,
+    "wof:lastmodified":1690938929,
     "wof:name":"\u0632\u0627\u064a\u0648",
     "wof:parent_id":890455271,
     "wof:placetype":"locality",

--- a/data/421/176/751/421176751.geojson
+++ b/data/421/176/751/421176751.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u062a\u0627\u0648\u0646\u0627\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Taounate"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0627\u0648\u0646\u0627\u062a"
     ],
@@ -44,6 +47,9 @@
     ],
     "name:deu_x_preferred":[
         "Taounate"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03b1\u03bf\u03c5\u03bd\u03ac\u03c4\u03b5"
     ],
     "name:eng_x_preferred":[
         "Taounat"
@@ -148,7 +154,7 @@
         }
     ],
     "wof:id":421176751,
-    "wof:lastmodified":1669161812,
+    "wof:lastmodified":1690938940,
     "wof:name":"Taounat",
     "wof:parent_id":890418103,
     "wof:placetype":"locality",

--- a/data/421/178/889/421178889.geojson
+++ b/data/421/178/889/421178889.geojson
@@ -27,11 +27,17 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0639\u064a\u0648\u0646 \u0627\u0644\u0634\u0631\u0642\u064a\u0647"
     ],
+    "name:ast_x_preferred":[
+        "El Aioun Sidi Mellouk"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0639\u06cc\u0648\u0646"
     ],
     "name:cat_x_preferred":[
         "El Aioun Sidi Mellouk"
+    ],
+    "name:ceb_x_preferred":[
+        "El Aioun Sidi Mellou"
     ],
     "name:deu_x_preferred":[
         "El A\u00efoun Sidi Mellouk"
@@ -65,6 +71,9 @@
     ],
     "name:swe_x_preferred":[
         "El Aioun Sidi Mellouk"
+    ],
+    "name:swe_x_variant":[
+        "El A\u00efoun Sidi Mellouk"
     ],
     "name:und_x_variant":[
         "Al \u2019Youn"
@@ -128,7 +137,7 @@
         }
     ],
     "wof:id":421178889,
-    "wof:lastmodified":1669161817,
+    "wof:lastmodified":1690938940,
     "wof:name":"\u0627\u0644\u0639\u064a\u0648\u0646 \u0633\u064a\u062f\u064a \u0645\u0644\u0648\u0643",
     "wof:parent_id":1108784813,
     "wof:placetype":"locality",

--- a/data/421/180/041/421180041.geojson
+++ b/data/421/180/041/421180041.geojson
@@ -33,6 +33,9 @@
     "name:azb_x_preferred":[
         "\u062a\u0632\u0646\u06cc\u062a"
     ],
+    "name:bel_x_preferred":[
+        "\u0422\u044b\u0437\u043d\u0456\u0442"
+    ],
     "name:ben_x_preferred":[
         "\u09a4\u09bf\u09af\u09a8\u09bf\u09a4"
     ],
@@ -320,7 +323,7 @@
         }
     ],
     "wof:id":421180041,
-    "wof:lastmodified":1669161818,
+    "wof:lastmodified":1690938928,
     "wof:name":"Tiznit",
     "wof:parent_id":890428801,
     "wof:placetype":"locality",

--- a/data/421/180/197/421180197.geojson
+++ b/data/421/180/197/421180197.geojson
@@ -33,6 +33,9 @@
     "name:cat_x_preferred":[
         "Tafraout"
     ],
+    "name:ceb_x_preferred":[
+        "Tafraout"
+    ],
     "name:dan_x_preferred":[
         "Tafraout"
     ],
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421180197,
-    "wof:lastmodified":1669161819,
+    "wof:lastmodified":1690938928,
     "wof:name":"Tafraout",
     "wof:parent_id":890428801,
     "wof:placetype":"locality",

--- a/data/421/183/733/421183733.geojson
+++ b/data/421/183/733/421183733.geojson
@@ -27,6 +27,9 @@
     "name:cat_x_preferred":[
         "Sidi Smail"
     ],
+    "name:ceb_x_preferred":[
+        "Sidi Smail"
+    ],
     "name:cym_x_preferred":[
         "Sidi Sma\u00efl"
     ],
@@ -43,6 +46,9 @@
         "Sidi Sma\u00efl"
     ],
     "name:nld_x_preferred":[
+        "Sidi Smail"
+    ],
+    "name:swe_x_preferred":[
         "Sidi Smail"
     ],
     "name:und_x_variant":[
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":421183733,
-    "wof:lastmodified":1669161820,
+    "wof:lastmodified":1690938940,
     "wof:name":"\u0633\u064a\u062f\u064a \u0627\u0633\u0645\u0627\u0639\u064a\u0644",
     "wof:parent_id":890445399,
     "wof:placetype":"locality",

--- a/data/421/190/007/421190007.geojson
+++ b/data/421/190/007/421190007.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u062e\u0645\u064a\u0633\u0627\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Khemisset"
+    ],
     "name:azb_x_preferred":[
         "\u062e\u0645\u06cc\u0633\u0627\u062a"
     ],
@@ -242,7 +245,7 @@
         }
     ],
     "wof:id":421190007,
-    "wof:lastmodified":1669161822,
+    "wof:lastmodified":1690938932,
     "wof:name":"Al Khemisset",
     "wof:parent_id":890453897,
     "wof:placetype":"locality",

--- a/data/421/190/041/421190041.geojson
+++ b/data/421/190/041/421190041.geojson
@@ -80,7 +80,8 @@
     ],
     "name:eng_x_variant":[
         "Mazaghan",
-        "El Jadida"
+        "El Jadida",
+        "Sinigal"
     ],
     "name:epo_x_preferred":[
         "El Jadida"
@@ -389,7 +390,7 @@
         }
     ],
     "wof:id":421190041,
-    "wof:lastmodified":1669161827,
+    "wof:lastmodified":1690938931,
     "wof:name":"Al Jadida",
     "wof:parent_id":890445399,
     "wof:placetype":"locality",

--- a/data/421/190/051/421190051.geojson
+++ b/data/421/190/051/421190051.geojson
@@ -66,6 +66,9 @@
         "Kasba A\u00eft Youdi",
         "Ksiba"
     ],
+    "name:uzb_x_preferred":[
+        "El Ksiba"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421190051,
-    "wof:lastmodified":1669161828,
+    "wof:lastmodified":1690938936,
     "wof:name":"El Ksiba",
     "wof:parent_id":890452779,
     "wof:placetype":"locality",

--- a/data/421/190/053/421190053.geojson
+++ b/data/421/190/053/421190053.geojson
@@ -30,11 +30,17 @@
     "name:arz_x_preferred":[
         "\u0643\u0644\u0645\u064a\u0645"
     ],
+    "name:ast_x_preferred":[
+        "Guelmim"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0644\u0645\u06cc\u0645"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0413\u0443\u043b\u0456\u043c\u0456\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u0413\u0443\u043b\u0456\u043c\u0456\u043d"
     ],
     "name:cat_x_preferred":[
         "Guelmim"
@@ -90,6 +96,9 @@
     "name:lit_x_preferred":[
         "Gelmimas"
     ],
+    "name:msa_x_preferred":[
+        "Guelmim"
+    ],
     "name:nld_x_preferred":[
         "Guelmim"
     ],
@@ -119,6 +128,9 @@
     ],
     "name:swe_x_preferred":[
         "Guelmim"
+    ],
+    "name:tur_x_preferred":[
+        "Kelmim"
     ],
     "name:ukr_x_preferred":[
         "\u0413\u0435\u043b\u044c\u043c\u0456\u043c"
@@ -285,7 +297,7 @@
         }
     ],
     "wof:id":421190053,
-    "wof:lastmodified":1669161829,
+    "wof:lastmodified":1690938932,
     "wof:name":"Guelmim",
     "wof:parent_id":1108784815,
     "wof:placetype":"locality",

--- a/data/421/190/071/421190071.geojson
+++ b/data/421/190/071/421190071.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u062e\u0646\u064a\u0641\u0631\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Khenifra"
+    ],
     "name:azb_x_preferred":[
         "\u062e\u0646\u06cc\u0641\u0631\u0647"
     ],
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":421190071,
-    "wof:lastmodified":1669161832,
+    "wof:lastmodified":1690938932,
     "wof:name":"Khenifra",
     "wof:parent_id":1108784791,
     "wof:placetype":"locality",

--- a/data/421/190/075/421190075.geojson
+++ b/data/421/190/075/421190075.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u062c\u0631\u0627\u062f\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Yerada"
+    ],
     "name:azb_x_preferred":[
         "\u062c\u0631\u0627\u062f\u0647"
     ],
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":421190075,
-    "wof:lastmodified":1669161833,
+    "wof:lastmodified":1690938935,
     "wof:name":"Jerada",
     "wof:parent_id":1108784775,
     "wof:placetype":"locality",

--- a/data/421/190/085/421190085.geojson
+++ b/data/421/190/085/421190085.geojson
@@ -33,6 +33,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0646\u0627\u0638\u0648\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Nador"
+    ],
     "name:azb_x_preferred":[
         "\u0646\u0627\u0638\u0648\u0631"
     ],
@@ -247,7 +250,7 @@
         }
     ],
     "wof:id":421190085,
-    "wof:lastmodified":1669161834,
+    "wof:lastmodified":1690938932,
     "wof:name":"Al Nador",
     "wof:parent_id":890455271,
     "wof:placetype":"locality",

--- a/data/421/190/089/421190089.geojson
+++ b/data/421/190/089/421190089.geojson
@@ -33,6 +33,9 @@
     "name:arz_x_preferred":[
         "\u0648\u0631\u0632\u0627\u0632\u0627\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Ouarzazate"
+    ],
     "name:aze_x_preferred":[
         "Varzazat"
     ],
@@ -68,6 +71,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039f\u03c5\u03b1\u03c1\u03b6\u03b1\u03b6\u03ac\u03c4\u03b5"
+    ],
+    "name:ell_x_variant":[
+        "\u039f\u03c5\u03b1\u03c1\u03b6\u03b1\u03b6\u03ac\u03c4"
     ],
     "name:eng_x_preferred":[
         "Ouarzazate"
@@ -253,7 +259,7 @@
         }
     ],
     "wof:id":421190089,
-    "wof:lastmodified":1669161835,
+    "wof:lastmodified":1690938935,
     "wof:name":"Ouarzazate",
     "wof:parent_id":1108784843,
     "wof:placetype":"locality",

--- a/data/421/190/095/421190095.geojson
+++ b/data/421/190/095/421190095.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u0648\u0632\u0627\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Ouazzane"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0632\u0627\u0646"
     ],
@@ -255,7 +258,7 @@
         }
     ],
     "wof:id":421190095,
-    "wof:lastmodified":1669161836,
+    "wof:lastmodified":1690938936,
     "wof:name":"Quazzane",
     "wof:parent_id":1108784797,
     "wof:placetype":"locality",

--- a/data/421/190/099/421190099.geojson
+++ b/data/421/190/099/421190099.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u0633\u0637\u0627\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Settat"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0637\u0627\u062a"
     ],
@@ -43,6 +46,12 @@
         "Settat"
     ],
     "name:ceb_x_preferred":[
+        "Settat"
+    ],
+    "name:ceb_x_variant":[
+        "Settat City"
+    ],
+    "name:ces_x_preferred":[
         "Settat"
     ],
     "name:cym_x_preferred":[
@@ -152,6 +161,9 @@
     ],
     "name:sin_x_preferred":[
         "\u0dc3\u0dd9\u0da7\u0dca\u0da7\u0da7\u0dca"
+    ],
+    "name:slk_x_preferred":[
+        "Settat"
     ],
     "name:spa_x_preferred":[
         "Settat"
@@ -336,7 +348,7 @@
         }
     ],
     "wof:id":421190099,
-    "wof:lastmodified":1669161837,
+    "wof:lastmodified":1690938933,
     "wof:name":"Settat",
     "wof:parent_id":1108784833,
     "wof:placetype":"locality",

--- a/data/421/190/111/421190111.geojson
+++ b/data/421/190/111/421190111.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u0635\u0641\u0631\u0648"
     ],
+    "name:ast_x_preferred":[
+        "Sefrou"
+    ],
     "name:azb_x_preferred":[
         "\u0635\u0641\u0631\u0648"
     ],
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421190111,
-    "wof:lastmodified":1669163390,
+    "wof:lastmodified":1690938933,
     "wof:name":"Sefru",
     "wof:parent_id":890440849,
     "wof:placetype":"locality",

--- a/data/421/190/117/421190117.geojson
+++ b/data/421/190/117/421190117.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u0633\u064a\u062f\u0649 \u0642\u0627\u0633\u0645"
     ],
+    "name:ast_x_preferred":[
+        "Sidi Kacem"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0642\u0627\u0633\u0645"
     ],
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":421190117,
-    "wof:lastmodified":1669161840,
+    "wof:lastmodified":1690938934,
     "wof:name":"Sidi Qasim",
     "wof:parent_id":890429091,
     "wof:placetype":"locality",

--- a/data/421/190/119/421190119.geojson
+++ b/data/421/190/119/421190119.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u0633\u064a\u062f\u0649 \u0633\u0644\u064a\u0645\u0627\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Sidi Slimane"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0633\u0644\u06cc\u0645\u0627\u0646"
     ],
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":421190119,
-    "wof:lastmodified":1669161841,
+    "wof:lastmodified":1690938934,
     "wof:name":"Sidi Sliman",
     "wof:parent_id":1108784809,
     "wof:placetype":"locality",

--- a/data/421/190/129/421190129.geojson
+++ b/data/421/190/129/421190129.geojson
@@ -30,11 +30,17 @@
     "name:arz_x_preferred":[
         "\u0637\u0627\u0646\u0637\u0627\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Tan-Tan"
+    ],
     "name:azb_x_preferred":[
         "\u0637\u0627\u0646\u0637\u0627\u0646"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0422\u0430\u043d-\u0422\u0430\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u0422\u0430\u043d-\u0422\u0430\u043d"
     ],
     "name:ben_x_preferred":[
         "\u09a4\u09be\u09a8-\u09a4\u09be\u09a8"
@@ -312,7 +318,7 @@
         }
     ],
     "wof:id":421190129,
-    "wof:lastmodified":1669161843,
+    "wof:lastmodified":1690938933,
     "wof:name":"Tan-Tan",
     "wof:parent_id":890418107,
     "wof:placetype":"locality",

--- a/data/421/190/131/421190131.geojson
+++ b/data/421/190/131/421190131.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u062a\u0627\u0631\u0648\u062f\u0627\u0646\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Taroudant"
+    ],
     "name:ben_x_preferred":[
         "\u09a4\u09be\u09b0\u09c1\u09a6\u09be\u09a8\u09cd\u09a4"
     ],
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":421190131,
-    "wof:lastmodified":1669161844,
+    "wof:lastmodified":1690938934,
     "wof:name":"Taroudant",
     "wof:parent_id":890445395,
     "wof:placetype":"locality",

--- a/data/421/190/133/421190133.geojson
+++ b/data/421/190/133/421190133.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u062a\u0627\u0632\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Taza"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0627\u0632\u0647"
     ],
@@ -330,7 +333,7 @@
         }
     ],
     "wof:id":421190133,
-    "wof:lastmodified":1669161845,
+    "wof:lastmodified":1690938930,
     "wof:name":"Taza",
     "wof:parent_id":890436791,
     "wof:placetype":"locality",

--- a/data/421/190/139/421190139.geojson
+++ b/data/421/190/139/421190139.geojson
@@ -162,6 +162,9 @@
     "name:vie_x_preferred":[
         "Tinghir"
     ],
+    "name:wln_x_preferred":[
+        "Tinrhir"
+    ],
     "name:zho_x_preferred":[
         "\u5ef7\u5409\u723e"
     ],
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":421190139,
-    "wof:lastmodified":1669161846,
+    "wof:lastmodified":1690938935,
     "wof:name":"Tinghir",
     "wof:parent_id":1108784839,
     "wof:placetype":"locality",

--- a/data/421/190/143/421190143.geojson
+++ b/data/421/190/143/421190143.geojson
@@ -81,6 +81,9 @@
     "name:chv_x_preferred":[
         "\u0424\u0435\u0441"
     ],
+    "name:ckb_x_preferred":[
+        "\u0641\u0627\u0633"
+    ],
     "name:cym_x_preferred":[
         "F\u00e8s"
     ],
@@ -160,6 +163,9 @@
     "name:ido_x_preferred":[
         "Fez"
     ],
+    "name:ile_x_preferred":[
+        "Fez"
+    ],
     "name:ind_x_preferred":[
         "Fez"
     ],
@@ -216,6 +222,9 @@
     ],
     "name:mal_x_preferred":[
         "\u0d2b\u0d46\u0d38\u0d4d"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0424\u044d\u0441"
     ],
     "name:mkd_x_preferred":[
         "\u0424\u0435\u0441"
@@ -282,6 +291,9 @@
     ],
     "name:shi_x_preferred":[
         "Fas"
+    ],
+    "name:slk_x_preferred":[
+        "F\u00e1s"
     ],
     "name:slv_x_preferred":[
         "Fes"
@@ -517,7 +529,7 @@
         }
     ],
     "wof:id":421190143,
-    "wof:lastmodified":1669163386,
+    "wof:lastmodified":1690938933,
     "wof:megacity":1,
     "wof:name":"Fes-Ville-Nouvelle",
     "wof:parent_id":890454333,

--- a/data/421/192/419/421192419.geojson
+++ b/data/421/192/419/421192419.geojson
@@ -39,6 +39,9 @@
     "name:fra_x_preferred":[
         "M'Hamid El Ghizlane"
     ],
+    "name:jpn_x_preferred":[
+        "\u30de\u30a2\u30df\u30c9"
+    ],
     "name:lit_x_preferred":[
         "Mhamidas"
     ],
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421192419,
-    "wof:lastmodified":1669161849,
+    "wof:lastmodified":1690938924,
     "wof:name":"Mhamid",
     "wof:parent_id":890424149,
     "wof:placetype":"locality",

--- a/data/421/195/127/421195127.geojson
+++ b/data/421/195/127/421195127.geojson
@@ -55,6 +55,9 @@
     "name:und_x_variant":[
         "Ben el Ouidane"
     ],
+    "name:uzb_x_preferred":[
+        "Bin El Ouidane"
+    ],
     "qs:gn_country":"MA",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":2555364,
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421195127,
-    "wof:lastmodified":1669161855,
+    "wof:lastmodified":1690938924,
     "wof:name":"Bin el Ouidane",
     "wof:parent_id":1108784827,
     "wof:placetype":"locality",

--- a/data/421/195/177/421195177.geojson
+++ b/data/421/195/177/421195177.geojson
@@ -33,6 +33,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u042d\u0440\u0444\u0443\u0434"
     ],
+    "name:bel_x_variant":[
+        "\u042d\u0440\u0444\u0443\u0434"
+    ],
     "name:cat_x_preferred":[
         "Erfoud"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05d0\u05e8\u05e4\u05d5\u05d3"
+    ],
+    "name:hye_x_preferred":[
+        "\u0537\u0580\u0586\u0578\u0582\u0564"
     ],
     "name:ita_x_preferred":[
         "Erfoud"
@@ -89,6 +95,9 @@
     ],
     "name:swe_x_preferred":[
         "Erfoud"
+    ],
+    "name:swe_x_variant":[
+        "Arfoud"
     ],
     "name:zho_x_preferred":[
         "\u5384\u592b"
@@ -149,7 +158,7 @@
         }
     ],
     "wof:id":421195177,
-    "wof:lastmodified":1669161856,
+    "wof:lastmodified":1690938925,
     "wof:name":"Erfoud",
     "wof:parent_id":1108784773,
     "wof:placetype":"locality",

--- a/data/421/195/181/421195181.geojson
+++ b/data/421/195/181/421195181.geojson
@@ -45,6 +45,9 @@
     "name:nld_x_preferred":[
         "Tazzarine"
     ],
+    "name:swe_x_preferred":[
+        "Tazarine"
+    ],
     "qs:gn_country":"MA",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":2529101,
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421195181,
-    "wof:lastmodified":1669161857,
+    "wof:lastmodified":1690938924,
     "wof:name":"Tazzarine",
     "wof:parent_id":890424149,
     "wof:placetype":"locality",

--- a/data/421/195/277/421195277.geojson
+++ b/data/421/195/277/421195277.geojson
@@ -63,6 +63,9 @@
     "name:swe_x_preferred":[
         "Tameslouht"
     ],
+    "name:swe_x_variant":[
+        "Tameslohte"
+    ],
     "name:und_x_variant":[
         "Tameslout"
     ],
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421195277,
-    "wof:lastmodified":1669161858,
+    "wof:lastmodified":1690938925,
     "wof:name":"Tameslouht",
     "wof:parent_id":1108784801,
     "wof:placetype":"locality",

--- a/data/421/195/289/421195289.geojson
+++ b/data/421/195/289/421195289.geojson
@@ -21,8 +21,14 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0644\u0627\u064a \u0627\u062f\u0631\u064a\u0633 \u0632\u0631\u0647\u0648\u0646"
     ],
+    "name:ara_x_variant":[
+        "\u0645\u0648\u0644\u0627\u064a \u0625\u062f\u0631\u064a\u0633 \u0632\u0631\u0647\u0648\u0646"
+    ],
     "name:ary_x_preferred":[
         "\u0645\u0648\u0644\u0627\u064a \u0627\u062f\u0631\u064a\u0633 \u0632\u0631\u0647\u0648\u0646"
+    ],
+    "name:ary_x_variant":[
+        "\u0645\u0648\u0644\u0627\u064a \u062f\u0631\u064a\u0633 \u0632\u0631\u0647\u0648\u0646"
     ],
     "name:arz_x_preferred":[
         "\u0645\u0648\u0644\u0627\u0649 \u0627\u062f\u0631\u064a\u0633 \u0632\u0631\u0647\u0648\u0646"
@@ -86,6 +92,9 @@
     ],
     "name:swe_x_preferred":[
         "Moulay Idriss"
+    ],
+    "name:tur_x_preferred":[
+        "Mevley \u0130dris Zirhun"
     ],
     "name:ukr_x_preferred":[
         "\u041c\u0443\u043b\u0430\u0439-\u0406\u0434\u0440\u0456\u0441-\u0417\u0435\u0440\u0433\u0443\u043d"
@@ -152,7 +161,7 @@
         }
     ],
     "wof:id":421195289,
-    "wof:lastmodified":1669161861,
+    "wof:lastmodified":1690938924,
     "wof:name":"Moulay Idriss",
     "wof:parent_id":1108784837,
     "wof:placetype":"locality",

--- a/data/421/195/947/421195947.geojson
+++ b/data/421/195/947/421195947.geojson
@@ -27,6 +27,9 @@
     "name:arz_x_preferred":[
         "\u0628\u0646 \u0633\u0644\u064a\u0645\u0627\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Ben Slimane"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646 \u0633\u0644\u06cc\u0645\u0627\u0646"
     ],
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":421195947,
-    "wof:lastmodified":1669161863,
+    "wof:lastmodified":1690938924,
     "wof:name":"Ben Sliman",
     "wof:parent_id":890436421,
     "wof:placetype":"locality",

--- a/data/421/196/309/421196309.geojson
+++ b/data/421/196/309/421196309.geojson
@@ -51,6 +51,9 @@
     "name:fra_x_preferred":[
         "Merzouga"
     ],
+    "name:hye_x_preferred":[
+        "\u0544\u0565\u0580\u0566\u0578\u0582\u0563\u0561"
+    ],
     "name:ita_x_preferred":[
         "Merzouga"
     ],
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421196309,
-    "wof:lastmodified":1669161865,
+    "wof:lastmodified":1690938929,
     "wof:name":"Merzouga",
     "wof:parent_id":1108784773,
     "wof:placetype":"locality",

--- a/data/421/196/365/421196365.geojson
+++ b/data/421/196/365/421196365.geojson
@@ -48,6 +48,9 @@
     "name:fra_x_preferred":[
         "A\u00eft Baha"
     ],
+    "name:kab_x_preferred":[
+        "Ayt Baha"
+    ],
     "name:nld_x_preferred":[
         "Ait Baha"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:shi_x_preferred":[
         "Ayt Baha"
+    ],
+    "name:swe_x_preferred":[
+        "A\u00eft Baha"
     ],
     "name:zho_x_preferred":[
         "\u963f\u4f0a\u7279\u5df4\u54c8"
@@ -115,7 +121,7 @@
         }
     ],
     "wof:id":421196365,
-    "wof:lastmodified":1669161866,
+    "wof:lastmodified":1690938929,
     "wof:name":"Ait Baha",
     "wof:parent_id":890445395,
     "wof:placetype":"locality",

--- a/data/421/197/253/421197253.geojson
+++ b/data/421/197/253/421197253.geojson
@@ -173,6 +173,9 @@
     "name:nob_x_preferred":[
         "T\u00e9touan"
     ],
+    "name:oci_x_preferred":[
+        "Tetoan"
+    ],
     "name:pol_x_preferred":[
         "Tetuan"
     ],
@@ -304,7 +307,7 @@
         }
     ],
     "wof:id":421197253,
-    "wof:lastmodified":1669161867,
+    "wof:lastmodified":1690938937,
     "wof:name":"\u062a\u0637\u0648\u0627\u0646",
     "wof:parent_id":890421483,
     "wof:placetype":"locality",

--- a/data/421/199/651/421199651.geojson
+++ b/data/421/199/651/421199651.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u0641\u0643\u064a\u0643"
     ],
+    "name:ast_x_preferred":[
+        "Figuig"
+    ],
     "name:azb_x_preferred":[
         "\u0641\u06a9\u06cc\u06a9"
     ],
@@ -223,7 +226,7 @@
         }
     ],
     "wof:id":421199651,
-    "wof:lastmodified":1669161867,
+    "wof:lastmodified":1690938938,
     "wof:name":"Figuig",
     "wof:parent_id":1108784825,
     "wof:placetype":"locality",

--- a/data/421/199/989/421199989.geojson
+++ b/data/421/199/989/421199989.geojson
@@ -78,6 +78,9 @@
     "name:swe_x_preferred":[
         "Midelt"
     ],
+    "name:wln_x_preferred":[
+        "Midele"
+    ],
     "name:zho_x_preferred":[
         "\u7c73\u5fb7\u52d2\u7279"
     ],
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421199989,
-    "wof:lastmodified":1669161868,
+    "wof:lastmodified":1690938938,
     "wof:name":"Midelt",
     "wof:parent_id":1108784795,
     "wof:placetype":"locality",

--- a/data/421/200/921/421200921.geojson
+++ b/data/421/200/921/421200921.geojson
@@ -30,6 +30,9 @@
     "name:arz_x_preferred":[
         "\u0648\u062c\u062f\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Oujda. \u0627\u0644\u0645\u063a\u0631\u0628"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u062c\u062f\u0647"
     ],
@@ -167,6 +170,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0914\u091c\u0926\u093e"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0423\u0434\u0436\u0434\u0430"
     ],
     "name:mkd_x_preferred":[
         "\u0423\u045f\u0434\u0430"
@@ -411,7 +417,7 @@
         }
     ],
     "wof:id":421200921,
-    "wof:lastmodified":1669161870,
+    "wof:lastmodified":1690938938,
     "wof:name":"Oujda",
     "wof:parent_id":890453895,
     "wof:placetype":"locality",

--- a/data/421/202/335/421202335.geojson
+++ b/data/421/202/335/421202335.geojson
@@ -117,6 +117,9 @@
     "name:guj_x_preferred":[
         "\u0ab2\u0abe\u0aaf\u0acb\u0aa8"
     ],
+    "name:hau_x_preferred":[
+        "Laayoune"
+    ],
     "name:heb_x_preferred":[
         "\u05dc\u05e2\u05d9\u05d5\u05df"
     ],
@@ -357,7 +360,7 @@
         }
     ],
     "wof:id":421202335,
-    "wof:lastmodified":1669909870,
+    "wof:lastmodified":1690938927,
     "wof:name":"Laayoune",
     "wof:parent_id":1796661371,
     "wof:placetype":"locality",

--- a/data/421/202/343/421202343.geojson
+++ b/data/421/202/343/421202343.geojson
@@ -60,6 +60,9 @@
     "name:und_x_variant":[
         "Kasba bou Znika"
     ],
+    "name:zho_x_preferred":[
+        "\u5e03\u8332\u5c3c\u5361"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":421202343,
-    "wof:lastmodified":1669161871,
+    "wof:lastmodified":1690938927,
     "wof:name":"Bouznika",
     "wof:parent_id":890436421,
     "wof:placetype":"locality",

--- a/data/421/202/455/421202455.geojson
+++ b/data/421/202/455/421202455.geojson
@@ -27,6 +27,9 @@
     "name:arz_x_preferred":[
         "\u0634\u0641\u0634\u0627\u0648\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Chefchaouen"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0641\u0634\u0627\u0648\u0646"
     ],
@@ -79,6 +82,9 @@
     "name:hrv_x_preferred":[
         "Chefchaouen"
     ],
+    "name:hun_x_preferred":[
+        "Sefs\u00e1ven"
+    ],
     "name:hye_x_preferred":[
         "\u0547\u0565\u0586\u0577\u0561\u0578\u0582\u0565\u0576"
     ],
@@ -103,8 +109,14 @@
     "name:lit_x_preferred":[
         "\u0160ef\u0161auenas"
     ],
+    "name:msa_x_preferred":[
+        "Chefchaouen"
+    ],
     "name:nld_x_preferred":[
         "Chefchaouen"
+    ],
+    "name:oci_x_preferred":[
+        "Chauen"
     ],
     "name:pol_x_preferred":[
         "Szafszawan"
@@ -120,6 +132,9 @@
     ],
     "name:rus_x_variant":[
         "\u0428\u0435\u0444\u0448\u0430\u0443\u0435\u043d"
+    ],
+    "name:sco_x_preferred":[
+        "Chefchaouen"
     ],
     "name:shi_x_preferred":[
         "Ccawn"
@@ -216,7 +231,7 @@
         }
     ],
     "wof:id":421202455,
-    "wof:lastmodified":1669161872,
+    "wof:lastmodified":1690938926,
     "wof:name":"Chefchaouene",
     "wof:parent_id":890453883,
     "wof:placetype":"locality",

--- a/data/856/326/93/85632693.geojson
+++ b/data/856/326/93/85632693.geojson
@@ -55,6 +55,9 @@
     "name:ang_x_preferred":[
         "Morocco"
     ],
+    "name:anp_x_preferred":[
+        "\u092e\u094b\u0930\u094b\u0915\u094d\u0915\u094b"
+    ],
     "name:ara_x_preferred":[
         "\u0627\u0644\u0645\u063a\u0631\u0628"
     ],
@@ -169,7 +172,8 @@
     ],
     "name:ceb_x_variant":[
         "Morocco",
-        "Kamarrokuhan"
+        "Kamarrokuhan",
+        "Kamarokuhan"
     ],
     "name:ces_x_preferred":[
         "Maroko"
@@ -343,6 +347,9 @@
     "name:gor_x_preferred":[
         "Maroko"
     ],
+    "name:gpe_x_preferred":[
+        "Morocco"
+    ],
     "name:grn_x_preferred":[
         "Marru\u00e9ko"
     ],
@@ -351,6 +358,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0aae\u0acb\u0ab0\u0acb\u0a95\u0acd\u0a95\u0acb"
+    ],
+    "name:gur_x_preferred":[
+        "Morocco"
     ],
     "name:hak_x_preferred":[
         "Morocco"
@@ -378,6 +388,9 @@
     ],
     "name:hil_x_preferred":[
         "Kamarrokuhan"
+    ],
+    "name:hil_x_variant":[
+        "Kamarokuhan"
     ],
     "name:hin_x_preferred":[
         "\u092e\u094b\u0930\u0915\u094d\u0915\u094b"
@@ -491,6 +504,9 @@
     "name:kir_x_preferred":[
         "\u041c\u0430\u0440\u043e\u043a\u043a\u043e"
     ],
+    "name:kom_x_preferred":[
+        "\u041c\u0430\u0440\u043e\u043a\u043a\u043e"
+    ],
     "name:kon_x_preferred":[
         "Maroko"
     ],
@@ -499,6 +515,9 @@
     ],
     "name:krj_x_preferred":[
         "Kamarrokuhan"
+    ],
+    "name:krj_x_variant":[
+        "Kamarokuhan"
     ],
     "name:kur_x_preferred":[
         "Maroko"
@@ -547,6 +566,9 @@
     ],
     "name:lld_x_preferred":[
         "Marocco"
+    ],
+    "name:lld_x_variant":[
+        "Maroch"
     ],
     "name:lmo_x_preferred":[
         "Maroch"
@@ -696,7 +718,8 @@
         "Morocco"
     ],
     "name:pam_x_variant":[
-        "Kamarrokuan"
+        "Kamarrokuan",
+        "Kamarokuan"
     ],
     "name:pan_x_preferred":[
         "\u0a2e\u0a4b\u0a30\u0a3e\u0a15\u0a4b"
@@ -889,7 +912,8 @@
     ],
     "name:tgl_x_variant":[
         "Morocco",
-        "Kamarrokuhan"
+        "Kamarrokuhan",
+        "Marueko"
     ],
     "name:tha_x_preferred":[
         "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e42\u0e21\u0e23\u0e47\u0e2d\u0e01\u0e42\u0e01"
@@ -899,6 +923,9 @@
     ],
     "name:tir_x_preferred":[
         "\u121e\u122e\u12ae"
+    ],
+    "name:tok_x_preferred":[
+        "ma Malipe"
     ],
     "name:ton_x_preferred":[
         "Molako"
@@ -914,6 +941,9 @@
     ],
     "name:tuk_x_preferred":[
         "Marokko"
+    ],
+    "name:tum_x_preferred":[
+        "Morocco"
     ],
     "name:tur_x_preferred":[
         "Fas"
@@ -972,7 +1002,8 @@
         "Morocco"
     ],
     "name:war_x_variant":[
-        "Kamarrokuhan"
+        "Kamarrokuhan",
+        "Kamarokuhan"
     ],
     "name:wln_x_preferred":[
         "Marok"
@@ -1250,7 +1281,7 @@
         "fra",
         "tzm"
     ],
-    "wof:lastmodified":1669163209,
+    "wof:lastmodified":1690938901,
     "wof:name":"Morocco",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/858/022/55/85802255.geojson
+++ b/data/858/022/55/85802255.geojson
@@ -59,6 +59,9 @@
     "name:und_x_variant":[
         "Grand Aguedal"
     ],
+    "name:zho_x_preferred":[
+        "\u963f\u683c\u9054\u723e\u5340"
+    ],
     "qs:gn_adm0_cc":"MA",
     "qs:gn_fcode":"PPLX",
     "qs:gn_local":2538475,
@@ -91,11 +94,11 @@
     "src:lbl_centroid":"yerbashapes",
     "wd:wordcount":106,
     "wof:belongsto":[
+        1796661377,
         102191573,
         85632693,
         421190103,
-        890437999,
-        1796661377
+        890437999
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -124,7 +127,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1669163392,
+    "wof:lastmodified":1690938902,
     "wof:name":"Agdal",
     "wof:parent_id":421190103,
     "wof:placetype":"neighbourhood",

--- a/data/890/416/633/890416633.geojson
+++ b/data/890/416/633/890416633.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Adaghas"
     ],
+    "name:ceb_x_preferred":[
+        "Adaghas"
+    ],
     "name:deu_x_preferred":[
         "Adaghas"
     ],
@@ -51,6 +54,9 @@
         "Adaghas (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Adaghas"
+    ],
+    "name:swe_x_preferred":[
         "Adaghas"
     ],
     "qs:name":"Adaghas",
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890416633,
-    "wof:lastmodified":1669163395,
+    "wof:lastmodified":1690939075,
     "wof:name":"Adaghas",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/416/645/890416645.geojson
+++ b/data/890/416/645/890416645.geojson
@@ -83,6 +83,9 @@
     "name:swe_x_preferred":[
         "Midelt"
     ],
+    "name:wln_x_preferred":[
+        "Midele"
+    ],
     "name:zho_x_preferred":[
         "\u7c73\u5fb7\u52d2\u7279"
     ],
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":890416645,
-    "wof:lastmodified":1669163399,
+    "wof:lastmodified":1690939074,
     "wof:name":"Midelt",
     "wof:parent_id":1108784795,
     "wof:placetype":"localadmin",

--- a/data/890/416/651/890416651.geojson
+++ b/data/890/416/651/890416651.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Houderrane"
     ],
+    "name:ceb_x_preferred":[
+        "Houderrane"
+    ],
     "name:eng_x_preferred":[
         "Houderrane"
     ],
@@ -42,6 +45,9 @@
         "Houderrane (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Houderrane"
+    ],
+    "name:swe_x_preferred":[
         "Houderrane"
     ],
     "qs:name":"Houderrane",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890416651,
-    "wof:lastmodified":1669163399,
+    "wof:lastmodified":1690939076,
     "wof:name":"Houderrane",
     "wof:parent_id":890453897,
     "wof:placetype":"localadmin",

--- a/data/890/416/653/890416653.geojson
+++ b/data/890/416/653/890416653.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Maaziz"
     ],
+    "name:ceb_x_preferred":[
+        "Maaziz"
+    ],
     "name:eng_x_preferred":[
         "Maaziz"
     ],
@@ -46,6 +49,9 @@
         "Ma\u00e2ziz"
     ],
     "name:nld_x_preferred":[
+        "Maaziz"
+    ],
+    "name:swe_x_preferred":[
         "Maaziz"
     ],
     "name:urd_x_preferred":[
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":890416653,
-    "wof:lastmodified":1669163400,
+    "wof:lastmodified":1690939088,
     "wof:name":"Maaziz",
     "wof:parent_id":890453897,
     "wof:placetype":"localadmin",

--- a/data/890/416/655/890416655.geojson
+++ b/data/890/416/655/890416655.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Ait Bazza"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Bazza"
+    ],
     "name:eng_x_preferred":[
         "Ait Bazza"
     ],
@@ -48,6 +51,9 @@
         "Ait Bazza (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Ait Bazza"
+    ],
+    "name:swe_x_preferred":[
         "Ait Bazza"
     ],
     "qs:name":"Ait Bazza",
@@ -90,7 +96,7 @@
         }
     ],
     "wof:id":890416655,
-    "wof:lastmodified":1669163401,
+    "wof:lastmodified":1690939086,
     "wof:name":"Ait Bazza",
     "wof:parent_id":890436419,
     "wof:placetype":"localadmin",

--- a/data/890/416/673/890416673.geojson
+++ b/data/890/416/673/890416673.geojson
@@ -31,10 +31,16 @@
     "name:arz_x_preferred":[
         "\u0648\u0627\u062f\u0649 \u0644\u0648"
     ],
+    "name:ast_x_preferred":[
+        "Oued Laou"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0627\u062f \u0644\u0648"
     ],
     "name:cat_x_preferred":[
+        "Oued Laou"
+    ],
+    "name:ceb_x_preferred":[
         "Oued Laou"
     ],
     "name:deu_x_preferred":[
@@ -70,6 +76,9 @@
     ],
     "name:spa_x_variant":[
         "Uad Lau"
+    ],
+    "name:swe_x_preferred":[
+        "Oued Laou"
     ],
     "name:urd_x_preferred":[
         "\u0648\u0627\u062f \u0644\u0627\u0648"
@@ -108,7 +117,7 @@
         }
     ],
     "wof:id":890416673,
-    "wof:lastmodified":1669163403,
+    "wof:lastmodified":1690939074,
     "wof:name":"Oued Laou",
     "wof:parent_id":890421483,
     "wof:placetype":"localadmin",

--- a/data/890/416/677/890416677.geojson
+++ b/data/890/416/677/890416677.geojson
@@ -53,6 +53,9 @@
     "name:swe_x_preferred":[
         "Anzou"
     ],
+    "name:uzb_x_preferred":[
+        "Anzou"
+    ],
     "qs:name":"Anzou",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890416677,
-    "wof:lastmodified":1669163404,
+    "wof:lastmodified":1690939086,
     "wof:name":"Anzou",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/416/687/890416687.geojson
+++ b/data/890/416/687/890416687.geojson
@@ -37,6 +37,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0643\u0627\u062f\u064a\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Agadir"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u06a9\u0627\u062f\u06cc\u0631"
     ],
@@ -367,7 +370,7 @@
         }
     ],
     "wof:id":890416687,
-    "wof:lastmodified":1669163406,
+    "wof:lastmodified":1690939075,
     "wof:name":"Agadir",
     "wof:parent_id":890429099,
     "wof:placetype":"localadmin",

--- a/data/890/416/693/890416693.geojson
+++ b/data/890/416/693/890416693.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Korimate"
     ],
+    "name:ceb_x_preferred":[
+        "Korimate"
+    ],
     "name:eng_x_preferred":[
         "Korimate"
     ],
@@ -42,6 +45,9 @@
         "Korimate (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Korimate"
+    ],
+    "name:swe_x_preferred":[
         "Korimate"
     ],
     "qs:name":"Korimate",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890416693,
-    "wof:lastmodified":1669163408,
+    "wof:lastmodified":1690939077,
     "wof:name":"Korimate",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/416/699/890416699.geojson
+++ b/data/890/416/699/890416699.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Lamrabih"
     ],
+    "name:ceb_x_preferred":[
+        "Lamrabih"
+    ],
     "name:eng_x_preferred":[
         "Lamrabih"
     ],
@@ -42,6 +45,9 @@
         "Lamrabih (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Lamrabih"
+    ],
+    "name:swe_x_preferred":[
         "Lamrabih"
     ],
     "name:urd_x_preferred":[
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890416699,
-    "wof:lastmodified":1669163410,
+    "wof:lastmodified":1690939086,
     "wof:name":"Lamrabih",
     "wof:parent_id":890429091,
     "wof:placetype":"localadmin",

--- a/data/890/416/703/890416703.geojson
+++ b/data/890/416/703/890416703.geojson
@@ -69,6 +69,9 @@
     "name:swe_x_preferred":[
         "Ain Bni Mathar"
     ],
+    "name:swe_x_variant":[
+        "A\u00efn Bni Mathar"
+    ],
     "name:zho_x_preferred":[
         "\u57c3\u6069-\u5df4\u5c3c-\u9a6c\u7279\u54c8\u5c14"
     ],
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":890416703,
-    "wof:lastmodified":1669163410,
+    "wof:lastmodified":1690939083,
     "wof:name":"Bni Mathar",
     "wof:parent_id":1108784775,
     "wof:placetype":"localadmin",

--- a/data/890/416/707/890416707.geojson
+++ b/data/890/416/707/890416707.geojson
@@ -57,6 +57,9 @@
     "name:swe_x_preferred":[
         "Ain Erreggada"
     ],
+    "name:swe_x_variant":[
+        "A\u00efn Erreggada"
+    ],
     "qs:name":"Ain Erreggada",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":890416707,
-    "wof:lastmodified":1669163412,
+    "wof:lastmodified":1690939073,
     "wof:name":"Ain Erreggada",
     "wof:parent_id":1108784771,
     "wof:placetype":"localadmin",

--- a/data/890/416/709/890416709.geojson
+++ b/data/890/416/709/890416709.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Ahl Oued Za"
     ],
+    "name:ceb_x_preferred":[
+        "Ahl Oued Za"
+    ],
     "name:eng_x_preferred":[
         "Ahl Oued Za"
     ],
@@ -48,6 +51,9 @@
         "Ahl Oued Za (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Ahl Oued Za"
+    ],
+    "name:swe_x_preferred":[
         "Ahl Oued Za"
     ],
     "name:urd_x_preferred":[
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890416709,
-    "wof:lastmodified":1669163413,
+    "wof:lastmodified":1690939072,
     "wof:name":"Ahl Oued Za",
     "wof:parent_id":1108784813,
     "wof:placetype":"localadmin",

--- a/data/890/416/743/890416743.geojson
+++ b/data/890/416/743/890416743.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "A\u00eft Mzal"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Mzal"
+    ],
     "name:eng_x_preferred":[
         "Ait Mzal"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:shi_x_preferred":[
         "Ayt M\u1e93al"
+    ],
+    "name:swe_x_preferred":[
+        "Ait Mzal"
     ],
     "qs:name":"Ait Mzal",
     "qs:photos_9r":0,
@@ -89,7 +95,7 @@
         }
     ],
     "wof:id":890416743,
-    "wof:lastmodified":1669163419,
+    "wof:lastmodified":1690939089,
     "wof:name":"Ait Mzal",
     "wof:parent_id":1108784831,
     "wof:placetype":"localadmin",

--- a/data/890/416/747/890416747.geojson
+++ b/data/890/416/747/890416747.geojson
@@ -51,6 +51,9 @@
     "name:nld_x_preferred":[
         "Tissint"
     ],
+    "name:nob_x_preferred":[
+        "Tissint"
+    ],
     "name:swe_x_preferred":[
         "Tissint"
     ],
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":890416747,
-    "wof:lastmodified":1669163420,
+    "wof:lastmodified":1690939079,
     "wof:name":"Tissint",
     "wof:parent_id":890453851,
     "wof:placetype":"localadmin",

--- a/data/890/416/759/890416759.geojson
+++ b/data/890/416/759/890416759.geojson
@@ -74,6 +74,9 @@
         "Tifariti (CR)",
         "Tifariti (Commune Rurale)"
     ],
+    "name:gle_x_preferred":[
+        "Tifariti"
+    ],
     "name:glg_x_preferred":[
         "Tifariti"
     ],
@@ -103,6 +106,9 @@
     ],
     "name:lit_x_preferred":[
         "Tifaritis"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0422\u0438\u0444\u0430\u0440\u0438\u0442\u0438"
     ],
     "name:mlt_x_preferred":[
         "Tifariti"
@@ -183,7 +189,7 @@
         }
     ],
     "wof:id":890416759,
-    "wof:lastmodified":1669163422,
+    "wof:lastmodified":1690939084,
     "wof:name":"Tifariti",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/890/416/775/890416775.geojson
+++ b/data/890/416/775/890416775.geojson
@@ -34,6 +34,9 @@
     "name:arz_x_preferred":[
         "\u0648\u0627\u062f\u0649 \u0632\u0645"
     ],
+    "name:ast_x_preferred":[
+        "Oued Zem"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0627\u062f\u0632\u0645"
     ],
@@ -198,7 +201,7 @@
         }
     ],
     "wof:id":890416775,
-    "wof:lastmodified":1669163426,
+    "wof:lastmodified":1690939089,
     "wof:name":"Oued Zem",
     "wof:parent_id":890422519,
     "wof:placetype":"localadmin",

--- a/data/890/416/779/890416779.geojson
+++ b/data/890/416/779/890416779.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Sidi Belyout"
     ],
+    "name:ceb_x_preferred":[
+        "Sidi Belyout"
+    ],
     "name:eng_x_preferred":[
         "Sidi Belyout"
     ],
@@ -45,6 +48,9 @@
         "Sidi Belyout"
     ],
     "name:nld_x_preferred":[
+        "Sidi Belyout"
+    ],
+    "name:swe_x_preferred":[
         "Sidi Belyout"
     ],
     "qs:name":"Sidi Belyout",
@@ -77,7 +83,7 @@
         }
     ],
     "wof:id":890416779,
-    "wof:lastmodified":1669163428,
+    "wof:lastmodified":1690939081,
     "wof:name":"Sidi Belyout",
     "wof:parent_id":1796661359,
     "wof:placetype":"localadmin",

--- a/data/890/416/817/890416817.geojson
+++ b/data/890/416/817/890416817.geojson
@@ -37,6 +37,9 @@
     "name:ceb_x_preferred":[
         "Tamri"
     ],
+    "name:deu_x_preferred":[
+        "Tamri"
+    ],
     "name:eng_x_preferred":[
         "Tamri"
     ],
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":890416817,
-    "wof:lastmodified":1669163440,
+    "wof:lastmodified":1690939074,
     "wof:name":"Tamri",
     "wof:parent_id":890429099,
     "wof:placetype":"localadmin",

--- a/data/890/416/829/890416829.geojson
+++ b/data/890/416/829/890416829.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Tilougguite"
     ],
+    "name:ceb_x_preferred":[
+        "Tilougguite"
+    ],
     "name:eng_x_preferred":[
         "Tilougguite"
     ],
@@ -43,6 +46,12 @@
     ],
     "name:ita_x_preferred":[
         "Tilougguite"
+    ],
+    "name:swe_x_preferred":[
+        "Tilougguite"
+    ],
+    "name:uzb_x_preferred":[
+        "Tilouggit"
     ],
     "qs:name":"Tilougguite",
     "qs:photos_9r":0,
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":890416829,
-    "wof:lastmodified":1669163444,
+    "wof:lastmodified":1690939073,
     "wof:name":"Tilougguite",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/416/831/890416831.geojson
+++ b/data/890/416/831/890416831.geojson
@@ -50,6 +50,9 @@
     "name:swe_x_preferred":[
         "Timoulilt"
     ],
+    "name:uzb_x_preferred":[
+        "Timulilt"
+    ],
     "qs:name":"Timoulilt",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890416831,
-    "wof:lastmodified":1669163445,
+    "wof:lastmodified":1690939086,
     "wof:name":"Timoulilt",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/416/833/890416833.geojson
+++ b/data/890/416/833/890416833.geojson
@@ -54,6 +54,9 @@
     "name:swe_x_preferred":[
         "Zaouiat Cheikh"
     ],
+    "name:uzb_x_preferred":[
+        "Zaouiat Cheikh"
+    ],
     "qs:name":"Zaouiat Cheikh",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":890416833,
-    "wof:lastmodified":1669163446,
+    "wof:lastmodified":1690939077,
     "wof:name":"Zaouiat Cheikh",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/416/847/890416847.geojson
+++ b/data/890/416/847/890416847.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Takoucht"
     ],
+    "name:ceb_x_preferred":[
+        "Takoucht"
+    ],
     "name:eng_x_preferred":[
         "Takoucht"
     ],
@@ -45,6 +48,9 @@
         "Takoucht (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Takoucht"
+    ],
+    "name:swe_x_preferred":[
         "Takoucht"
     ],
     "qs:name":"Takoucht",
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890416847,
-    "wof:lastmodified":1669163450,
+    "wof:lastmodified":1690939085,
     "wof:name":"Takoucht",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/416/869/890416869.geojson
+++ b/data/890/416/869/890416869.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "M'Khalif"
     ],
+    "name:ceb_x_preferred":[
+        "M Khalif"
+    ],
     "name:eng_x_preferred":[
         "M'Khalif"
     ],
@@ -42,6 +45,9 @@
         "M Khalif (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "M'Khalif"
+    ],
+    "name:swe_x_preferred":[
         "M'Khalif"
     ],
     "qs:name":"M Khalif",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890416869,
-    "wof:lastmodified":1669163456,
+    "wof:lastmodified":1690939077,
     "wof:name":"M Khalif",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/416/873/890416873.geojson
+++ b/data/890/416/873/890416873.geojson
@@ -35,6 +35,9 @@
     "name:ceb_x_preferred":[
         "Dcheira El Jihadia"
     ],
+    "name:ces_x_preferred":[
+        "Dcheira El Jihadia"
+    ],
     "name:deu_x_preferred":[
         "Dcheira El Jihadia"
     ],
@@ -53,6 +56,9 @@
         "Dcheira",
         "Dcheira (CR)",
         "Dcheira (Commune Rurale)"
+    ],
+    "name:ita_x_preferred":[
+        "Dcheira El Jihadia"
     ],
     "name:jpn_x_preferred":[
         "\u30c0\u30b7\u30eb\u30fb\u30a8\u30eb\u30fb\u30b8\u30cf\u30fc\u30c9"
@@ -119,7 +125,7 @@
         }
     ],
     "wof:id":890416873,
-    "wof:lastmodified":1669163457,
+    "wof:lastmodified":1690939073,
     "wof:name":"Dcheira El Jihadia",
     "wof:parent_id":890429093,
     "wof:placetype":"localadmin",

--- a/data/890/416/913/890416913.geojson
+++ b/data/890/416/913/890416913.geojson
@@ -23,10 +23,14 @@
         "\u0645\u0643\u0646\u0627\u0633 (\u0627\u0644\u0628\u0644\u062f\u064a\u0629)"
     ],
     "name:ara_x_variant":[
-        "\u0645\u0648\u0644\u0627\u064a \u0627\u062f\u0631\u064a\u0633 \u0632\u0631\u0647\u0648\u0646"
+        "\u0645\u0648\u0644\u0627\u064a \u0627\u062f\u0631\u064a\u0633 \u0632\u0631\u0647\u0648\u0646",
+        "\u0645\u0648\u0644\u0627\u064a \u0625\u062f\u0631\u064a\u0633 \u0632\u0631\u0647\u0648\u0646"
     ],
     "name:ary_x_preferred":[
         "\u0645\u0648\u0644\u0627\u064a \u0627\u062f\u0631\u064a\u0633 \u0632\u0631\u0647\u0648\u0646"
+    ],
+    "name:ary_x_variant":[
+        "\u0645\u0648\u0644\u0627\u064a \u062f\u0631\u064a\u0633 \u0632\u0631\u0647\u0648\u0646"
     ],
     "name:arz_x_preferred":[
         "\u0645\u0648\u0644\u0627\u0649 \u0627\u062f\u0631\u064a\u0633 \u0632\u0631\u0647\u0648\u0646"
@@ -87,6 +91,9 @@
     "name:swe_x_preferred":[
         "Moulay Idriss"
     ],
+    "name:tur_x_preferred":[
+        "Mevley \u0130dris Zirhun"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0443\u043b\u0430\u0439-\u0406\u0434\u0440\u0456\u0441-\u0417\u0435\u0440\u0433\u0443\u043d"
     ],
@@ -128,7 +135,7 @@
         }
     ],
     "wof:id":890416913,
-    "wof:lastmodified":1669163464,
+    "wof:lastmodified":1690939081,
     "wof:name":"Moulay Driss Zerhoun",
     "wof:parent_id":1108784837,
     "wof:placetype":"localadmin",

--- a/data/890/416/919/890416919.geojson
+++ b/data/890/416/919/890416919.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Ouijjane"
     ],
+    "name:ceb_x_preferred":[
+        "Ouijjane"
+    ],
     "name:eng_x_preferred":[
         "Ouijjane"
     ],
@@ -42,6 +45,9 @@
         "Ouijjane (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Ouijjane"
+    ],
+    "name:swe_x_preferred":[
         "Ouijjane"
     ],
     "qs:name":"Ouijjane",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890416919,
-    "wof:lastmodified":1669163466,
+    "wof:lastmodified":1690939090,
     "wof:name":"Ouijjane",
     "wof:parent_id":890428801,
     "wof:placetype":"localadmin",

--- a/data/890/416/923/890416923.geojson
+++ b/data/890/416/923/890416923.geojson
@@ -50,6 +50,9 @@
     "name:ita_x_preferred":[
         "Ait Sedrate Jbel El Soufla"
     ],
+    "name:swe_x_preferred":[
+        "Ait Sedrate Jbel El Soufla"
+    ],
     "qs:name":"Ait Sedrate Jbel  El",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890416923,
-    "wof:lastmodified":1669163467,
+    "wof:lastmodified":1690939079,
     "wof:name":"Ait Sedrate Jbel El",
     "wof:parent_id":1108784839,
     "wof:placetype":"localadmin",

--- a/data/890/416/925/890416925.geojson
+++ b/data/890/416/925/890416925.geojson
@@ -23,7 +23,8 @@
         "\u0644\u0645\u0639\u0627\u062f\u0646\u0629"
     ],
     "name:ara_x_variant":[
-        "\u0628\u0646 \u0623\u062d\u0645\u062f"
+        "\u0628\u0646 \u0623\u062d\u0645\u062f",
+        "\u0627\u0628\u0646 \u0623\u062d\u0645\u062f"
     ],
     "name:ary_x_preferred":[
         "\u0628\u0646 \u062d\u0645\u062f"
@@ -31,8 +32,17 @@
     "name:arz_x_preferred":[
         "\u0628\u0646 \u0627\u062d\u0645\u062f"
     ],
+    "name:arz_x_variant":[
+        "\u0627\u0628\u0646 \u0627\u062d\u0645\u062f"
+    ],
+    "name:ast_x_preferred":[
+        "Ben Ahmed"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646 \u0627\u062d\u0645\u062f"
+    ],
+    "name:azb_x_variant":[
+        "\u0627\u0628\u0646 \u0627\u062d\u0645\u062f"
     ],
     "name:cat_x_preferred":[
         "Ben Ahmed"
@@ -45,6 +55,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0628\u0646 \u0627\u062d\u0645\u062f"
+    ],
+    "name:fas_x_variant":[
+        "\u0627\u0628\u0646 \u0627\u062d\u0645\u062f"
     ],
     "name:fra_x_preferred":[
         "Ben Ahmed"
@@ -105,7 +118,7 @@
         }
     ],
     "wof:id":890416925,
-    "wof:lastmodified":1669163468,
+    "wof:lastmodified":1690939081,
     "wof:name":"Ben Ahmed",
     "wof:parent_id":1108784833,
     "wof:placetype":"localadmin",

--- a/data/890/416/943/890416943.geojson
+++ b/data/890/416/943/890416943.geojson
@@ -59,6 +59,9 @@
     "name:swe_x_preferred":[
         "Bouznika"
     ],
+    "name:zho_x_preferred":[
+        "\u5e03\u8332\u5c3c\u5361"
+    ],
     "qs:name":"Bouznika",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890416943,
-    "wof:lastmodified":1669163474,
+    "wof:lastmodified":1690939091,
     "wof:name":"Bouznika",
     "wof:parent_id":890436421,
     "wof:placetype":"localadmin",

--- a/data/890/416/949/890416949.geojson
+++ b/data/890/416/949/890416949.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0648\u0632\u0627\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Ouazzane"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0632\u0627\u0646"
     ],
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":890416949,
-    "wof:lastmodified":1669163477,
+    "wof:lastmodified":1690939080,
     "wof:name":"Ouezzane",
     "wof:parent_id":1108784797,
     "wof:placetype":"localadmin",

--- a/data/890/416/961/890416961.geojson
+++ b/data/890/416/961/890416961.geojson
@@ -54,6 +54,9 @@
         "Ait Baha (Commune Urbaine)",
         "A\u00eft Baha"
     ],
+    "name:kab_x_preferred":[
+        "Ayt Baha"
+    ],
     "name:nld_x_preferred":[
         "Ait Baha"
     ],
@@ -62,6 +65,9 @@
     ],
     "name:shi_x_preferred":[
         "Ayt Baha"
+    ],
+    "name:swe_x_preferred":[
+        "A\u00eft Baha"
     ],
     "name:zho_x_preferred":[
         "\u963f\u4f0a\u7279\u5df4\u54c8"
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":890416961,
-    "wof:lastmodified":1669163478,
+    "wof:lastmodified":1690939082,
     "wof:name":"Ait Baha",
     "wof:parent_id":1108784831,
     "wof:placetype":"localadmin",

--- a/data/890/416/963/890416963.geojson
+++ b/data/890/416/963/890416963.geojson
@@ -28,6 +28,9 @@
     "name:ary_x_preferred":[
         "\u0628\u064a\u0648\u06af\u0631\u0649"
     ],
+    "name:ary_x_variant":[
+        "\u0628\u064a\u0648\u0763\u0631\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u06cc\u0648\u06a9\u0631\u0647"
     ],
@@ -74,6 +77,9 @@
     "name:shi_x_preferred":[
         "Big\u02b7ra"
     ],
+    "name:spa_x_preferred":[
+        "Biougra"
+    ],
     "name:swe_x_preferred":[
         "Biougra"
     ],
@@ -114,7 +120,7 @@
         }
     ],
     "wof:id":890416963,
-    "wof:lastmodified":1669163479,
+    "wof:lastmodified":1690939072,
     "wof:name":"Biougra",
     "wof:parent_id":1108784831,
     "wof:placetype":"localadmin",

--- a/data/890/416/983/890416983.geojson
+++ b/data/890/416/983/890416983.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Sidi M'bark"
     ],
+    "name:ceb_x_preferred":[
+        "Sidi M Bark"
+    ],
     "name:eng_x_preferred":[
         "Sidi M'Bark"
     ],
@@ -42,6 +45,9 @@
         "Sidi M Bark (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Sidi M'Bark"
+    ],
+    "name:swe_x_preferred":[
         "Sidi M'Bark"
     ],
     "qs:name":"Sidi M Bark",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890416983,
-    "wof:lastmodified":1669163486,
+    "wof:lastmodified":1690939078,
     "wof:name":"Sidi M Bark",
     "wof:parent_id":1108784841,
     "wof:placetype":"localadmin",

--- a/data/890/416/985/890416985.geojson
+++ b/data/890/416/985/890416985.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Irigh N'Tahala"
     ],
+    "name:ceb_x_preferred":[
+        "Irigh N Tahala"
+    ],
     "name:eng_x_preferred":[
         "Irigh N'Tahala"
     ],
@@ -42,6 +45,9 @@
         "Irigh N Tahala (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Irigh N'Tahala"
+    ],
+    "name:swe_x_preferred":[
         "Irigh N'Tahala"
     ],
     "qs:name":"Irigh N Tahala",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890416985,
-    "wof:lastmodified":1669163487,
+    "wof:lastmodified":1690939080,
     "wof:name":"Irigh N Tahala",
     "wof:parent_id":890428801,
     "wof:placetype":"localadmin",

--- a/data/890/416/991/890416991.geojson
+++ b/data/890/416/991/890416991.geojson
@@ -25,27 +25,52 @@
     "name:ara_x_variant":[
         "\u0635\u062e\u0648\u0631 \u0627\u0644\u0631\u062d\u0627\u0645\u0646\u0629"
     ],
+    "name:ary_x_preferred":[
+        "\u0635\u062e\u0648\u0631 \u0627\u0644\u0631\u062d\u0627\u0645\u0646\u0629"
+    ],
     "name:cat_x_preferred":[
         "Skhour Rhamna"
     ],
     "name:ceb_x_preferred":[
         "Skhour Rhamna"
     ],
+    "name:ceb_x_variant":[
+        "Skhour des Rehamna"
+    ],
     "name:eng_x_preferred":[
         "Skhour Rhamna"
+    ],
+    "name:eng_x_variant":[
+        "Skhour Rehamna"
+    ],
+    "name:fas_x_preferred":[
+        "\u0633\u062e\u0648\u0631 \u0631\u062d\u0627\u0645\u0646\u0647"
     ],
     "name:fra_x_preferred":[
         "Skhour Rhamna"
     ],
     "name:fra_x_variant":[
         "Skhour Rhamna (CR)",
-        "Skhour Rhamna (Commune Rurale)"
+        "Skhour Rhamna (Commune Rurale)",
+        "Skhour Rehamna"
     ],
     "name:ita_x_preferred":[
         "Skhour Rhamna"
     ],
+    "name:ita_x_variant":[
+        "Skhour Rehamna"
+    ],
+    "name:nld_x_preferred":[
+        "Skhour Rehamna"
+    ],
     "name:swe_x_preferred":[
         "Skhour Rhamna"
+    ],
+    "name:swe_x_variant":[
+        "Skhour Rehamna"
+    ],
+    "name:zho_x_preferred":[
+        "\u65af\u5eab\u723e\u96f7\u54c8\u59c6\u7d0d"
     ],
     "qs:name":"Skhour Rhamna",
     "qs:photos_9r":0,
@@ -79,7 +104,7 @@
         }
     ],
     "wof:id":890416991,
-    "wof:lastmodified":1669158658,
+    "wof:lastmodified":1690939071,
     "wof:name":"Skhour Rhamna",
     "wof:parent_id":1108784803,
     "wof:placetype":"localadmin",

--- a/data/890/416/999/890416999.geojson
+++ b/data/890/416/999/890416999.geojson
@@ -59,6 +59,9 @@
     "name:swe_x_preferred":[
         "Deroua"
     ],
+    "name:urd_x_preferred":[
+        "\u062f\u0631\u0648\u06c1"
+    ],
     "name:zho_x_preferred":[
         "\u5fb7\u9b6f\u963f"
     ],
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":890416999,
-    "wof:lastmodified":1669163490,
+    "wof:lastmodified":1690939072,
     "wof:name":"Deroua",
     "wof:parent_id":1108784793,
     "wof:placetype":"localadmin",

--- a/data/890/417/011/890417011.geojson
+++ b/data/890/417/011/890417011.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Oulad Cherki"
     ],
+    "name:ceb_x_preferred":[
+        "Oulad Cherki"
+    ],
     "name:eng_x_preferred":[
         "Oulad Cherki"
     ],
@@ -45,6 +48,9 @@
         "Oulad Cherki (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Oulad Cherki"
+    ],
+    "name:swe_x_preferred":[
         "Oulad Cherki"
     ],
     "qs:name":"Oulad Cherki",
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890417011,
-    "wof:lastmodified":1669163495,
+    "wof:lastmodified":1690939060,
     "wof:name":"Oulad Cherki",
     "wof:parent_id":1108784785,
     "wof:placetype":"localadmin",

--- a/data/890/417/023/890417023.geojson
+++ b/data/890/417/023/890417023.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0641\u0631\u0627\u0626\u0637\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Fraita"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0641\u0631\u0627\u0626\u0637\u0647"
     ],
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":890417023,
-    "wof:lastmodified":1669163499,
+    "wof:lastmodified":1690939049,
     "wof:name":"Fraita",
     "wof:parent_id":1108784785,
     "wof:placetype":"localadmin",

--- a/data/890/417/029/890417029.geojson
+++ b/data/890/417/029/890417029.geojson
@@ -32,6 +32,9 @@
     "name:arz_x_preferred":[
         "\u0641\u0643\u064a\u0643"
     ],
+    "name:ast_x_preferred":[
+        "Figuig"
+    ],
     "name:azb_x_preferred":[
         "\u0641\u06a9\u06cc\u06a9"
     ],
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":890417029,
-    "wof:lastmodified":1669163501,
+    "wof:lastmodified":1690939061,
     "wof:name":"Figuig",
     "wof:parent_id":1108784825,
     "wof:placetype":"localadmin",

--- a/data/890/417/033/890417033.geojson
+++ b/data/890/417/033/890417033.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0628\u0648\u0633\u0643\u0648\u0631\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Bouskoura"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u0633\u06a9\u0648\u0631\u0647"
     ],
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":890417033,
-    "wof:lastmodified":1669163503,
+    "wof:lastmodified":1690939065,
     "wof:name":"Bouskoura",
     "wof:parent_id":890424145,
     "wof:placetype":"localadmin",

--- a/data/890/417/041/890417041.geojson
+++ b/data/890/417/041/890417041.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Ain Dfali"
     ],
+    "name:ceb_x_preferred":[
+        "Ain Dfali"
+    ],
     "name:eng_x_preferred":[
         "Ain Dfali"
     ],
@@ -50,6 +53,9 @@
     ],
     "name:ita_x_preferred":[
         "A\u00efn Dfali"
+    ],
+    "name:swe_x_preferred":[
+        "Ain Dfali"
     ],
     "qs:name":"Ain Dfali",
     "qs:photos_9r":0,
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":890417041,
-    "wof:lastmodified":1669163506,
+    "wof:lastmodified":1690939050,
     "wof:name":"Ain Dfali",
     "wof:parent_id":890429091,
     "wof:placetype":"localadmin",

--- a/data/890/417/069/890417069.geojson
+++ b/data/890/417/069/890417069.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Ait Yaazem"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Yaazem"
+    ],
     "name:eng_x_preferred":[
         "Ait Yaazem"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:nld_x_preferred":[
         "Ait Yaazem"
+    ],
+    "name:swe_x_preferred":[
+        "A\u00eft Yaazem"
     ],
     "qs:name":"Ait Yaazem",
     "qs:photos_9r":0,
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890417069,
-    "wof:lastmodified":1669163511,
+    "wof:lastmodified":1690939065,
     "wof:name":"Ait Yaazem",
     "wof:parent_id":1108784789,
     "wof:placetype":"localadmin",

--- a/data/890/417/075/890417075.geojson
+++ b/data/890/417/075/890417075.geojson
@@ -53,6 +53,9 @@
     "name:swe_x_preferred":[
         "Had Bouhssoussen"
     ],
+    "name:uzb_x_preferred":[
+        "Had Bouhsoussen"
+    ],
     "qs:name":"Had Bouhssoussen",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890417075,
-    "wof:lastmodified":1669163513,
+    "wof:lastmodified":1690939061,
     "wof:name":"Had Bouhssoussen",
     "wof:parent_id":1108784791,
     "wof:placetype":"localadmin",

--- a/data/890/417/101/890417101.geojson
+++ b/data/890/417/101/890417101.geojson
@@ -37,6 +37,9 @@
     "name:ceb_x_preferred":[
         "Douar A\u00eft Mohammed"
     ],
+    "name:ceb_x_variant":[
+        "Ait M Hamed"
+    ],
     "name:deu_x_preferred":[
         "A\u00eft M\u2019hamed"
     ],
@@ -68,6 +71,12 @@
     ],
     "name:swe_x_preferred":[
         "Douar A\u00eft M'Hamed"
+    ],
+    "name:swe_x_variant":[
+        "A\u00eft M'Hamed"
+    ],
+    "name:uzb_x_preferred":[
+        "Ait M'Hamed"
     ],
     "qs:name":"Ait M Hamed",
     "qs:photos_9r":0,
@@ -101,7 +110,7 @@
         }
     ],
     "wof:id":890417101,
-    "wof:lastmodified":1669163522,
+    "wof:lastmodified":1690939059,
     "wof:name":"Ait M Hamed",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/417/103/890417103.geojson
+++ b/data/890/417/103/890417103.geojson
@@ -50,6 +50,9 @@
     "name:swe_x_preferred":[
         "El Hammam"
     ],
+    "name:uzb_x_preferred":[
+        "El Hammam"
+    ],
     "qs:name":"El Hammam",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890417103,
-    "wof:lastmodified":1669163523,
+    "wof:lastmodified":1690939047,
     "wof:name":"El Hammam",
     "wof:parent_id":1108784791,
     "wof:placetype":"localadmin",

--- a/data/890/417/105/890417105.geojson
+++ b/data/890/417/105/890417105.geojson
@@ -75,6 +75,9 @@
     "name:swe_x_preferred":[
         "Kelaat Mgouna"
     ],
+    "name:swe_x_variant":[
+        "Kalaat M'Gouna"
+    ],
     "qs:name":"Kalaat M'Gouna",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":890417105,
-    "wof:lastmodified":1669163524,
+    "wof:lastmodified":1690939048,
     "wof:name":"Kalaat M'Gouna",
     "wof:parent_id":1108784839,
     "wof:placetype":"localadmin",

--- a/data/890/417/107/890417107.geojson
+++ b/data/890/417/107/890417107.geojson
@@ -23,7 +23,8 @@
         "\u062a\u064a\u063a\u064a\u0631\u062a"
     ],
     "name:ara_x_variant":[
-        "\u0623\u0641\u0644\u0627 \u0627\u063a\u064a\u0631"
+        "\u0623\u0641\u0644\u0627 \u0627\u063a\u064a\u0631",
+        "\u0623\u0641\u0644\u0627 \u0625\u063a\u064a\u0631"
     ],
     "name:ary_x_preferred":[
         "\u0623\u0641\u0644\u0627 \u0625\u064a\u063a\u064a\u0631"
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":890417107,
-    "wof:lastmodified":1669163525,
+    "wof:lastmodified":1690939058,
     "wof:name":"Afella Ighir",
     "wof:parent_id":890428801,
     "wof:placetype":"localadmin",

--- a/data/890/417/113/890417113.geojson
+++ b/data/890/417/113/890417113.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Imi N'Fast"
     ],
+    "name:ceb_x_preferred":[
+        "Imi N Fast"
+    ],
     "name:eng_x_preferred":[
         "Imi N'Fast"
     ],
@@ -42,6 +45,9 @@
         "Imi N Fast (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Imi N'Fast"
+    ],
+    "name:swe_x_preferred":[
         "Imi N'Fast"
     ],
     "qs:name":"Imi N Fast",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890417113,
-    "wof:lastmodified":1669163528,
+    "wof:lastmodified":1690939067,
     "wof:name":"Imi N Fast",
     "wof:parent_id":1108784841,
     "wof:placetype":"localadmin",

--- a/data/890/417/127/890417127.geojson
+++ b/data/890/417/127/890417127.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Azrar"
     ],
+    "name:ceb_x_preferred":[
+        "Azrar"
+    ],
     "name:eng_x_preferred":[
         "Azrar"
     ],
@@ -42,6 +45,9 @@
         "Azrar (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Azrar"
+    ],
+    "name:swe_x_preferred":[
         "Azrar"
     ],
     "qs:name":"Azrar",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890417127,
-    "wof:lastmodified":1669163534,
+    "wof:lastmodified":1690939055,
     "wof:name":"Azrar",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/417/131/890417131.geojson
+++ b/data/890/417/131/890417131.geojson
@@ -31,11 +31,17 @@
     "name:arz_x_preferred":[
         "\u0643\u0644\u0645\u064a\u0645"
     ],
+    "name:ast_x_preferred":[
+        "Guelmim"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0644\u0645\u06cc\u0645"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0413\u0443\u043b\u0456\u043c\u0456\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u0413\u0443\u043b\u0456\u043c\u0456\u043d"
     ],
     "name:cat_x_preferred":[
         "Guelmim"
@@ -95,6 +101,9 @@
     "name:lit_x_preferred":[
         "Gelmimas"
     ],
+    "name:msa_x_preferred":[
+        "Guelmim"
+    ],
     "name:nld_x_preferred":[
         "Guelmim"
     ],
@@ -124,6 +133,9 @@
     ],
     "name:swe_x_preferred":[
         "Guelmim"
+    ],
+    "name:tur_x_preferred":[
+        "Kelmim"
     ],
     "name:ukr_x_preferred":[
         "\u0413\u0435\u043b\u044c\u043c\u0456\u043c"
@@ -174,7 +186,7 @@
         }
     ],
     "wof:id":890417131,
-    "wof:lastmodified":1669163536,
+    "wof:lastmodified":1690939057,
     "wof:name":"Guelmim",
     "wof:parent_id":1108784815,
     "wof:placetype":"localadmin",

--- a/data/890/417/135/890417135.geojson
+++ b/data/890/417/135/890417135.geojson
@@ -37,6 +37,9 @@
     "name:ceb_x_preferred":[
         "Ifrane Atlas Saghir"
     ],
+    "name:deu_x_preferred":[
+        "Ifrane Atlas Saghir"
+    ],
     "name:eng_x_preferred":[
         "Ifrane Atlas-Saghir"
     ],
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":890417135,
-    "wof:lastmodified":1669163537,
+    "wof:lastmodified":1690939047,
     "wof:name":"Ifrane Atlas Saghir",
     "wof:parent_id":1108784815,
     "wof:placetype":"localadmin",

--- a/data/890/417/165/890417165.geojson
+++ b/data/890/417/165/890417165.geojson
@@ -23,7 +23,8 @@
         "\u0622\u0633\u0641\u064a (\u0627\u0644\u0628\u0644\u062f\u064a\u0629)"
     ],
     "name:ara_x_variant":[
-        "\u0633\u0628\u062a \u0643\u0632\u0648\u0644\u0629"
+        "\u0633\u0628\u062a \u0643\u0632\u0648\u0644\u0629",
+        "\u0633\u0628\u062a \u062c\u0632\u0648\u0644\u0629"
     ],
     "name:ary_x_preferred":[
         "\u0633\u0628\u062a \u06af\u0632\u0648\u0644\u0629"
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":890417165,
-    "wof:lastmodified":1669163550,
+    "wof:lastmodified":1690939057,
     "wof:name":"Sebt Gzoula",
     "wof:parent_id":890445397,
     "wof:placetype":"localadmin",

--- a/data/890/417/171/890417171.geojson
+++ b/data/890/417/171/890417171.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Ait Sedrate Sahl El Gharbia"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Sedrate Sahl El"
+    ],
     "name:eng_x_preferred":[
         "Ait Sedrate Sahl El Gharbia"
     ],
@@ -45,10 +48,14 @@
     ],
     "name:fra_x_variant":[
         "Ait Sedrate Sahl El (CR)",
-        "Ait Sedrate Sahl El (Commune Rurale)"
+        "Ait Sedrate Sahl El (Commune Rurale)",
+        "A\u00eft Sedrate Sahl El Gharbia"
     ],
     "name:ita_x_preferred":[
         "Ait Sedrate Sahl El Gharbia"
+    ],
+    "name:swe_x_preferred":[
+        "A\u00eft Sedrate Sahl El Gharbia"
     ],
     "qs:name":"Ait Sedrate Sahl El",
     "qs:photos_9r":0,
@@ -82,7 +89,7 @@
         }
     ],
     "wof:id":890417171,
-    "wof:lastmodified":1669163552,
+    "wof:lastmodified":1690939067,
     "wof:name":"Ait Sedrate Sahl El",
     "wof:parent_id":1108784839,
     "wof:placetype":"localadmin",

--- a/data/890/417/173/890417173.geojson
+++ b/data/890/417/173/890417173.geojson
@@ -35,6 +35,9 @@
     "name:cat_x_preferred":[
         "Ighil N'Oumgoun"
     ],
+    "name:ceb_x_preferred":[
+        "Ighil N Oumgoun"
+    ],
     "name:eng_x_preferred":[
         "Ighil N'Oumgoun"
     ],
@@ -56,6 +59,9 @@
         "Ighil n'Oumgoun"
     ],
     "name:nld_x_preferred":[
+        "Ighil N'Oumgoun"
+    ],
+    "name:swe_x_preferred":[
         "Ighil N'Oumgoun"
     ],
     "qs:name":"Ighil N Oumgoun",
@@ -99,7 +105,7 @@
         }
     ],
     "wof:id":890417173,
-    "wof:lastmodified":1669163553,
+    "wof:lastmodified":1690939054,
     "wof:name":"Ighil N Oumgoun",
     "wof:parent_id":1108784839,
     "wof:placetype":"localadmin",

--- a/data/890/417/179/890417179.geojson
+++ b/data/890/417/179/890417179.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Imi N'Oulaoune"
     ],
+    "name:ceb_x_preferred":[
+        "Imi N Oulaoune"
+    ],
     "name:eng_x_preferred":[
         "Imi N'Oulaoune"
     ],
@@ -48,6 +51,9 @@
         "Imi N Oulaoune (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Imi N'Oulaoune"
+    ],
+    "name:swe_x_preferred":[
         "Imi N'Oulaoune"
     ],
     "qs:name":"Imi N Oulaoune",
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":890417179,
-    "wof:lastmodified":1669163557,
+    "wof:lastmodified":1690939067,
     "wof:name":"Imi N Oulaoune",
     "wof:parent_id":1108784843,
     "wof:placetype":"localadmin",

--- a/data/890/417/189/890417189.geojson
+++ b/data/890/417/189/890417189.geojson
@@ -32,6 +32,9 @@
     "name:cat_x_preferred":[
         "Sidi H'saine Ou Ali"
     ],
+    "name:ceb_x_preferred":[
+        "Sidi H Saine Ou Ali"
+    ],
     "name:eng_x_preferred":[
         "Sidi H'Saine Ou Ali"
     ],
@@ -46,6 +49,9 @@
         "Sidi Ali (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Sidi H'Saine Ou Ali"
+    ],
+    "name:swe_x_preferred":[
         "Sidi H'Saine Ou Ali"
     ],
     "qs:name":"Sidi H Saine Ou Ali",
@@ -89,7 +95,7 @@
         }
     ],
     "wof:id":890417189,
-    "wof:lastmodified":1669163560,
+    "wof:lastmodified":1690939055,
     "wof:name":"Sidi H Saine Ou Ali",
     "wof:parent_id":1108784841,
     "wof:placetype":"localadmin",

--- a/data/890/417/191/890417191.geojson
+++ b/data/890/417/191/890417191.geojson
@@ -50,6 +50,9 @@
     "name:swe_x_preferred":[
         "Ait Saadelli"
     ],
+    "name:uzb_x_preferred":[
+        "Ait Saadelli"
+    ],
     "qs:name":"Ait Saadelli",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890417191,
-    "wof:lastmodified":1669163561,
+    "wof:lastmodified":1690939057,
     "wof:name":"Ait Saadelli",
     "wof:parent_id":1108784791,
     "wof:placetype":"localadmin",

--- a/data/890/417/193/890417193.geojson
+++ b/data/890/417/193/890417193.geojson
@@ -50,6 +50,9 @@
     "name:ita_x_preferred":[
         "Ait Sedrate Jbel El Soufla"
     ],
+    "name:swe_x_preferred":[
+        "Ait Sedrate Jbel El Soufla"
+    ],
     "qs:name":"Ait Sedrate Jbel  El",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890417193,
-    "wof:lastmodified":1669163562,
+    "wof:lastmodified":1690939048,
     "wof:name":"Ait Sedrate Jbel El",
     "wof:parent_id":1108784839,
     "wof:placetype":"localadmin",

--- a/data/890/417/197/890417197.geojson
+++ b/data/890/417/197/890417197.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0628\u0631\u0634\u064a\u062f"
     ],
+    "name:ast_x_preferred":[
+        "Berrechid"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u0634\u06cc\u062f"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d9\u30ec\u30c1\u30c9"
+    ],
+    "name:jpn_x_variant":[
+        "\u30d9\u30ec\u30b7\u30c9"
     ],
     "name:kan_x_preferred":[
         "\u0cac\u0cb0\u0ccd\u0cb0\u0cc6\u0c9a\u0cbf\u0ca1\u0ccd"
@@ -204,7 +210,7 @@
         }
     ],
     "wof:id":890417197,
-    "wof:lastmodified":1669163563,
+    "wof:lastmodified":1690939058,
     "wof:name":"Berrechid",
     "wof:parent_id":1108784793,
     "wof:placetype":"localadmin",

--- a/data/890/417/201/890417201.geojson
+++ b/data/890/417/201/890417201.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Loulad"
     ],
+    "name:ceb_x_preferred":[
+        "Loulad"
+    ],
     "name:cym_x_preferred":[
         "Loulad"
     ],
@@ -51,6 +54,9 @@
         "Loulad"
     ],
     "name:nld_x_preferred":[
+        "Loulad"
+    ],
+    "name:swe_x_preferred":[
         "Loulad"
     ],
     "qs:name":"Loulad",
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890417201,
-    "wof:lastmodified":1669163564,
+    "wof:lastmodified":1690939065,
     "wof:name":"Loulad",
     "wof:parent_id":1108784833,
     "wof:placetype":"localadmin",

--- a/data/890/417/207/890417207.geojson
+++ b/data/890/417/207/890417207.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_variant":[
         "\u0644\u062d\u0644\u0627\u0641 \u0645\u0632\u0627\u0628"
     ],
+    "name:ceb_x_preferred":[
+        "Lahlaf M Zab"
+    ],
     "name:eng_x_preferred":[
         "Lahlaf M'Zab"
     ],
@@ -36,6 +39,9 @@
         "Lahlaf M Zab (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Lahlaf M'Zab"
+    ],
+    "name:swe_x_preferred":[
         "Lahlaf M'Zab"
     ],
     "name:urd_x_preferred":[
@@ -73,7 +79,7 @@
         }
     ],
     "wof:id":890417207,
-    "wof:lastmodified":1669156892,
+    "wof:lastmodified":1690939063,
     "wof:name":"Lahlaf M Zab",
     "wof:parent_id":1108784833,
     "wof:placetype":"localadmin",

--- a/data/890/417/225/890417225.geojson
+++ b/data/890/417/225/890417225.geojson
@@ -28,6 +28,12 @@
     "name:azb_x_preferred":[
         "\u0627\u0644\u062e\u06cc\u0627\u06cc\u0637\u0647"
     ],
+    "name:bul_x_preferred":[
+        "\u041b\u0430\u043a\u0445\u0438\u0430\u0438\u0442\u0430"
+    ],
+    "name:ceb_x_preferred":[
+        "Lakhiaita"
+    ],
     "name:eng_x_preferred":[
         "Lakhiaita"
     ],
@@ -42,6 +48,9 @@
         "Lakhiaita (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Lakhiaita"
+    ],
+    "name:swe_x_preferred":[
         "Lakhiaita"
     ],
     "name:urd_x_preferred":[
@@ -79,7 +88,7 @@
         }
     ],
     "wof:id":890417225,
-    "wof:lastmodified":1669156894,
+    "wof:lastmodified":1690939062,
     "wof:name":"Lakhiaita",
     "wof:parent_id":1108784793,
     "wof:placetype":"localadmin",

--- a/data/890/417/227/890417227.geojson
+++ b/data/890/417/227/890417227.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Sahel Oulad H'Riz"
     ],
+    "name:ceb_x_preferred":[
+        "Sahel Oulad H Riz"
+    ],
     "name:eng_x_preferred":[
         "Sahel Oulad H'Riz"
     ],
@@ -48,6 +51,9 @@
         "Sahel Oulad H Riz (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Sahel Oulad H'Riz"
+    ],
+    "name:swe_x_preferred":[
         "Sahel Oulad H'Riz"
     ],
     "name:urd_x_preferred":[
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890417227,
-    "wof:lastmodified":1669163574,
+    "wof:lastmodified":1690939049,
     "wof:name":"Sahel Oulad H Riz",
     "wof:parent_id":1108784793,
     "wof:placetype":"localadmin",

--- a/data/890/417/275/890417275.geojson
+++ b/data/890/417/275/890417275.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Oulad M'Hammed"
     ],
+    "name:ceb_x_preferred":[
+        "Oulad M Hammed"
+    ],
     "name:eng_x_preferred":[
         "Oulad M'Hammed"
     ],
@@ -43,6 +46,9 @@
         "Oulad M'Hammed"
     ],
     "name:ita_x_preferred":[
+        "Oulad M'Hammed"
+    ],
+    "name:swe_x_preferred":[
         "Oulad M'Hammed"
     ],
     "qs:name":"Oulad M Hammed",
@@ -77,7 +83,7 @@
         }
     ],
     "wof:id":890417275,
-    "wof:lastmodified":1669163586,
+    "wof:lastmodified":1690939052,
     "wof:name":"Oulad M Hammed",
     "wof:parent_id":1108784813,
     "wof:placetype":"localadmin",

--- a/data/890/417/291/890417291.geojson
+++ b/data/890/417/291/890417291.geojson
@@ -53,6 +53,9 @@
     "name:swe_x_preferred":[
         "Sabaa Aiyoun"
     ],
+    "name:swe_x_variant":[
+        "Saba\u00e2 A\u00efyoun"
+    ],
     "name:urd_x_preferred":[
         "\u0633\u0628\u0627 \u0627\u06cc\u0648\u06ba"
     ],
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890417291,
-    "wof:lastmodified":1669163592,
+    "wof:lastmodified":1690939064,
     "wof:name":"Sabaa Aiyoun",
     "wof:parent_id":1108784789,
     "wof:placetype":"localadmin",

--- a/data/890/418/103/890418103.geojson
+++ b/data/890/418/103/890418103.geojson
@@ -94,6 +94,9 @@
     "name:swe_x_preferred":[
         "Taounate"
     ],
+    "name:tur_x_preferred":[
+        "Tavnet"
+    ],
     "name:zho_x_preferred":[
         "\u9676\u7d0d\u7279\u7701"
     ],
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":890418103,
-    "wof:lastmodified":1669163622,
+    "wof:lastmodified":1690939097,
     "wof:name":"Taounate",
     "wof:parent_id":1796661365,
     "wof:placetype":"county",

--- a/data/890/418/107/890418107.geojson
+++ b/data/890/418/107/890418107.geojson
@@ -94,6 +94,9 @@
     "name:swe_x_preferred":[
         "Tan-Tan"
     ],
+    "name:tur_x_preferred":[
+        "Tan-Tan"
+    ],
     "name:und_x_variant":[
         "Province Tan-Tan"
     ],
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890418107,
-    "wof:lastmodified":1669163624,
+    "wof:lastmodified":1690939097,
     "wof:name":"Tan-Tan",
     "wof:parent_id":1796661367,
     "wof:placetype":"county",

--- a/data/890/420/263/890420263.geojson
+++ b/data/890/420/263/890420263.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Sidi Smail"
     ],
+    "name:ceb_x_preferred":[
+        "Sidi Smail"
+    ],
     "name:cym_x_preferred":[
         "Sidi Sma\u00efl"
     ],
@@ -52,6 +55,9 @@
         "Sidi Sma\u00efl"
     ],
     "name:nld_x_preferred":[
+        "Sidi Smail"
+    ],
+    "name:swe_x_preferred":[
         "Sidi Smail"
     ],
     "qs:name":"Sidi Smail",
@@ -86,7 +92,7 @@
         }
     ],
     "wof:id":890420263,
-    "wof:lastmodified":1669163625,
+    "wof:lastmodified":1690939096,
     "wof:name":"Sidi Smail",
     "wof:parent_id":890445399,
     "wof:placetype":"localadmin",

--- a/data/890/420/305/890420305.geojson
+++ b/data/890/420/305/890420305.geojson
@@ -50,6 +50,9 @@
     "name:swe_x_preferred":[
         "Dir El Ksiba"
     ],
+    "name:uzb_x_preferred":[
+        "Dir El Ksiba"
+    ],
     "qs:name":"Dir El Ksiba",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890420305,
-    "wof:lastmodified":1669163637,
+    "wof:lastmodified":1690939095,
     "wof:name":"Dir El Ksiba",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/420/307/890420307.geojson
+++ b/data/890/420/307/890420307.geojson
@@ -62,6 +62,9 @@
     "name:swe_x_preferred":[
         "Bradia"
     ],
+    "name:uzb_x_preferred":[
+        "Bradia"
+    ],
     "qs:name":"Bradia",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":890420307,
-    "wof:lastmodified":1669163637,
+    "wof:lastmodified":1690939091,
     "wof:name":"Bradia",
     "wof:parent_id":1108784787,
     "wof:placetype":"localadmin",

--- a/data/890/420/343/890420343.geojson
+++ b/data/890/420/343/890420343.geojson
@@ -50,6 +50,9 @@
     "name:swe_x_preferred":[
         "Foum El Anceur"
     ],
+    "name:uzb_x_preferred":[
+        "Foum El Anceur"
+    ],
     "qs:name":"Foum El Anceur",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890420343,
-    "wof:lastmodified":1669163645,
+    "wof:lastmodified":1690939097,
     "wof:name":"Foum El Anceur",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/420/347/890420347.geojson
+++ b/data/890/420/347/890420347.geojson
@@ -56,6 +56,9 @@
     "name:swe_x_preferred":[
         "Bni Chegdale"
     ],
+    "name:uzb_x_preferred":[
+        "Bni Chegdale"
+    ],
     "qs:name":"Bni Chegdale",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890420347,
-    "wof:lastmodified":1669163646,
+    "wof:lastmodified":1690939094,
     "wof:name":"Bni Chegdale",
     "wof:parent_id":1108784787,
     "wof:placetype":"localadmin",

--- a/data/890/421/479/890421479.geojson
+++ b/data/890/421/479/890421479.geojson
@@ -29,6 +29,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u064a\u0648\u0633\u0641\u064a\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Youssoufia"
+    ],
     "name:azb_x_preferred":[
         "\u06cc\u0648\u0633\u0641\u06cc\u0647"
     ],
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":890421479,
-    "wof:lastmodified":1669163650,
+    "wof:lastmodified":1690939046,
     "wof:name":"Youssoufia",
     "wof:parent_id":1108784821,
     "wof:placetype":"locality",

--- a/data/890/421/483/890421483.geojson
+++ b/data/890/421/483/890421483.geojson
@@ -95,6 +95,9 @@
     "name:swe_x_preferred":[
         "Tetouan"
     ],
+    "name:tur_x_preferred":[
+        "Tetuan"
+    ],
     "name:und_x_variant":[
         "Provincia de Tetu\u00e1n"
     ],
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":890421483,
-    "wof:lastmodified":1669163662,
+    "wof:lastmodified":1690939046,
     "wof:name":"Tetouan",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/890/422/513/890422513.geojson
+++ b/data/890/422/513/890422513.geojson
@@ -108,6 +108,9 @@
     "name:swe_x_preferred":[
         "Larache"
     ],
+    "name:tur_x_preferred":[
+        "El-Arayi\u015f"
+    ],
     "name:urd_x_preferred":[
         "\u0627\u0644\u0639\u0631\u0627\u0626\u0634 \u0635\u0648\u0628\u06c1"
     ],
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":890422513,
-    "wof:lastmodified":1669163671,
+    "wof:lastmodified":1690938971,
     "wof:name":"Larache",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/890/422/519/890422519.geojson
+++ b/data/890/422/519/890422519.geojson
@@ -94,6 +94,12 @@
     "name:swe_x_preferred":[
         "Khouribga Province"
     ],
+    "name:swe_x_variant":[
+        "Khouribga"
+    ],
+    "name:tur_x_preferred":[
+        "Huribke"
+    ],
     "name:zho_x_preferred":[
         "\u80e1\u91cc\u535c\u84cb\u7701"
     ],
@@ -147,7 +153,7 @@
         }
     ],
     "wof:id":890422519,
-    "wof:lastmodified":1669163676,
+    "wof:lastmodified":1690938969,
     "wof:name":"Khouribga",
     "wof:parent_id":1796661357,
     "wof:placetype":"county",

--- a/data/890/422/523/890422523.geojson
+++ b/data/890/422/523/890422523.geojson
@@ -100,6 +100,9 @@
     "name:swe_x_preferred":[
         "Assa-Zag"
     ],
+    "name:tur_x_preferred":[
+        "\u00c2sa-Zek"
+    ],
     "name:und_x_variant":[
         "\u0625\u0642\u0644\u064a\u0645 \u0622\u0633\u0627 \u0627\u0644\u0632\u0627\u0643"
     ],
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":890422523,
-    "wof:lastmodified":1669163677,
+    "wof:lastmodified":1690938971,
     "wof:name":"Assa-Zag",
     "wof:parent_id":1796661367,
     "wof:placetype":"county",

--- a/data/890/422/853/890422853.geojson
+++ b/data/890/422/853/890422853.geojson
@@ -28,6 +28,9 @@
     "name:cat_x_preferred":[
         "Moualine el Ghaba"
     ],
+    "name:ceb_x_preferred":[
+        "Moualine El Ghaba"
+    ],
     "name:eng_x_preferred":[
         "Moualine el Ghaba"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:nld_x_preferred":[
         "Moualine el Ghaba"
+    ],
+    "name:swe_x_preferred":[
+        "Moualine El Ghaba"
     ],
     "qs:name":"Moualine El Ghaba",
     "qs:photos_9r":0,
@@ -73,7 +79,7 @@
         }
     ],
     "wof:id":890422853,
-    "wof:lastmodified":1669156889,
+    "wof:lastmodified":1690938970,
     "wof:name":"Moualine El Ghaba",
     "wof:parent_id":890436421,
     "wof:placetype":"localadmin",

--- a/data/890/422/871/890422871.geojson
+++ b/data/890/422/871/890422871.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Oued L'Bour"
     ],
+    "name:ceb_x_preferred":[
+        "Oued L Bour"
+    ],
     "name:eng_x_preferred":[
         "Oued L'Bour"
     ],
@@ -45,6 +48,9 @@
         "Oued L Bour (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Oued L'Bour"
+    ],
+    "name:swe_x_preferred":[
         "Oued L'Bour"
     ],
     "qs:name":"Oued L Bour",
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890422871,
-    "wof:lastmodified":1669163682,
+    "wof:lastmodified":1690938970,
     "wof:name":"Oued L Bour",
     "wof:parent_id":890440847,
     "wof:placetype":"localadmin",

--- a/data/890/422/887/890422887.geojson
+++ b/data/890/422/887/890422887.geojson
@@ -53,6 +53,9 @@
     "name:swe_x_preferred":[
         "Amalou Ighriben"
     ],
+    "name:uzb_x_preferred":[
+        "Amalou Ighriben"
+    ],
     "qs:name":"Amalou Ighriben",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":890422887,
-    "wof:lastmodified":1669156516,
+    "wof:lastmodified":1690938968,
     "wof:name":"Amalou Ighriben",
     "wof:parent_id":1108784791,
     "wof:placetype":"localadmin",

--- a/data/890/422/889/890422889.geojson
+++ b/data/890/422/889/890422889.geojson
@@ -37,6 +37,9 @@
     "name:azb_x_preferred":[
         "\u062a\u0632\u0646\u06cc\u062a"
     ],
+    "name:bel_x_preferred":[
+        "\u0422\u044b\u0437\u043d\u0456\u0442"
+    ],
     "name:ben_x_preferred":[
         "\u09a4\u09bf\u09af\u09a8\u09bf\u09a4"
     ],
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":890422889,
-    "wof:lastmodified":1669163688,
+    "wof:lastmodified":1690938967,
     "wof:name":"Tiznit",
     "wof:parent_id":890428801,
     "wof:placetype":"localadmin",

--- a/data/890/422/891/890422891.geojson
+++ b/data/890/422/891/890422891.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0628\u0646 \u0633\u0644\u064a\u0645\u0627\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Ben Slimane"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646 \u0633\u0644\u06cc\u0645\u0627\u0646"
     ],
@@ -81,6 +84,9 @@
     "name:swe_x_preferred":[
         "Ben Slimane"
     ],
+    "name:swe_x_variant":[
+        "Benslimane"
+    ],
     "name:urd_x_preferred":[
         "\u0628\u0646 \u0633\u0644\u06cc\u0645\u0627\u0646"
     ],
@@ -121,7 +127,7 @@
         }
     ],
     "wof:id":890422891,
-    "wof:lastmodified":1669163689,
+    "wof:lastmodified":1690938970,
     "wof:name":"Benslimane",
     "wof:parent_id":890436421,
     "wof:placetype":"localadmin",

--- a/data/890/422/895/890422895.geojson
+++ b/data/890/422/895/890422895.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0639\u0631\u0648\u0649"
     ],
+    "name:ast_x_preferred":[
+        "Al Aaroui"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0639\u0631\u0648\u06cc"
     ],
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":890422895,
-    "wof:lastmodified":1669163690,
+    "wof:lastmodified":1690938968,
     "wof:name":"Al Aaroui",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/423/741/890423741.geojson
+++ b/data/890/423/741/890423741.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Laatamna"
     ],
+    "name:ceb_x_preferred":[
+        "Laatamna"
+    ],
     "name:eng_x_preferred":[
         "Laatamna"
     ],
@@ -47,6 +50,9 @@
     ],
     "name:ita_x_preferred":[
         "La\u00e2tamna"
+    ],
+    "name:swe_x_preferred":[
+        "Laatamna"
     ],
     "name:urd_x_preferred":[
         "\u0644\u0627\u0679\u0627\u0645\u0646\u0627"
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":890423741,
-    "wof:lastmodified":1669163693,
+    "wof:lastmodified":1690939002,
     "wof:name":"Laatamna",
     "wof:parent_id":1108784785,
     "wof:placetype":"localadmin",

--- a/data/890/423/753/890423753.geojson
+++ b/data/890/423/753/890423753.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Snada"
     ],
+    "name:eng_x_variant":[
+        "Znada"
+    ],
     "name:fra_x_preferred":[
         "Senada"
     ],
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":890423753,
-    "wof:lastmodified":1669163696,
+    "wof:lastmodified":1690938995,
     "wof:name":"Senada",
     "wof:parent_id":890429097,
     "wof:placetype":"localadmin",

--- a/data/890/423/773/890423773.geojson
+++ b/data/890/423/773/890423773.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0646\u0648\u0627\u0635\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Nouaceur"
+    ],
     "name:bul_x_preferred":[
         "\u041d\u043e\u0443\u0430\u0441\u0435\u0443\u0440"
     ],
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":890423773,
-    "wof:lastmodified":1669163701,
+    "wof:lastmodified":1690939010,
     "wof:name":"Nouaceur",
     "wof:parent_id":890424145,
     "wof:placetype":"localadmin",

--- a/data/890/423/787/890423787.geojson
+++ b/data/890/423/787/890423787.geojson
@@ -35,6 +35,9 @@
     "name:cat_x_preferred":[
         "Guelta Zemur"
     ],
+    "name:ceb_x_preferred":[
+        "Gueltat Zemmour"
+    ],
     "name:deu_x_preferred":[
         "Guelta Zemmur"
     ],
@@ -75,6 +78,9 @@
     "name:spa_x_preferred":[
         "Guelta Zemmur"
     ],
+    "name:swe_x_preferred":[
+        "Gueltat Zemmour"
+    ],
     "name:zho_x_preferred":[
         "\u683c\u5c14\u5854\u6cfd\u7a46\u5c14"
     ],
@@ -108,7 +114,7 @@
         }
     ],
     "wof:id":890423787,
-    "wof:lastmodified":1669163704,
+    "wof:lastmodified":1690939010,
     "wof:name":"Gueltat Zemmour",
     "wof:parent_id":1796661371,
     "wof:placetype":"localadmin",

--- a/data/890/423/805/890423805.geojson
+++ b/data/890/423/805/890423805.geojson
@@ -32,6 +32,9 @@
     "name:cat_x_preferred":[
         "Ouneine"
     ],
+    "name:ceb_x_preferred":[
+        "Ouneine"
+    ],
     "name:eng_x_preferred":[
         "Ouneine"
     ],
@@ -43,6 +46,9 @@
         "Ouneine (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Ouneine"
+    ],
+    "name:swe_x_preferred":[
         "Ouneine"
     ],
     "qs:name":"Ouneine",
@@ -77,7 +83,7 @@
         }
     ],
     "wof:id":890423805,
-    "wof:lastmodified":1669163707,
+    "wof:lastmodified":1690938999,
     "wof:name":"Ouneine",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/423/815/890423815.geojson
+++ b/data/890/423/815/890423815.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Oulad M'Hamed"
     ],
+    "name:ceb_x_preferred":[
+        "Oulad M Hamed"
+    ],
     "name:eng_x_preferred":[
         "Oulad M'Hamed"
     ],
@@ -42,6 +45,9 @@
         "Oulad M Hamed (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Oulad M'Hamed"
+    ],
+    "name:swe_x_preferred":[
         "Oulad M'Hamed"
     ],
     "qs:name":"Oulad M Hamed",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890423815,
-    "wof:lastmodified":1669163710,
+    "wof:lastmodified":1690939006,
     "wof:name":"Oulad M Hamed",
     "wof:parent_id":1108784833,
     "wof:placetype":"localadmin",

--- a/data/890/423/823/890423823.geojson
+++ b/data/890/423/823/890423823.geojson
@@ -31,6 +31,12 @@
     "name:cat_x_preferred":[
         "M'Zem Sanhaja"
     ],
+    "name:ceb_x_preferred":[
+        "M Zem Sanhaja"
+    ],
+    "name:deu_x_preferred":[
+        "M Zem Sanhaja"
+    ],
     "name:eng_x_preferred":[
         "M'Zem Sanhaja"
     ],
@@ -50,7 +56,13 @@
     "name:snd_x_preferred":[
         "\u0645\u0632\u064a\u0645 \u0633\u0627\u0646\u0647\u062c\u0627"
     ],
+    "name:spa_x_preferred":[
+        "M Zem Sanhaja"
+    ],
     "name:sqi_x_preferred":[
+        "M'Zem Sanhaja"
+    ],
+    "name:swe_x_preferred":[
         "M'Zem Sanhaja"
     ],
     "name:urd_x_preferred":[
@@ -88,7 +100,7 @@
         }
     ],
     "wof:id":890423823,
-    "wof:lastmodified":1669163714,
+    "wof:lastmodified":1690939006,
     "wof:name":"M Zem Sanhaja",
     "wof:parent_id":1108784785,
     "wof:placetype":"localadmin",

--- a/data/890/423/853/890423853.geojson
+++ b/data/890/423/853/890423853.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Oulad Mtaa"
     ],
+    "name:ceb_x_preferred":[
+        "Oulad Mtaa"
+    ],
     "name:eng_x_preferred":[
         "Oulad Mtaa"
     ],
@@ -48,6 +51,9 @@
         "Oulad Mtaa (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Oulad Mtaa"
+    ],
+    "name:swe_x_preferred":[
         "Oulad Mtaa"
     ],
     "name:urd_x_preferred":[
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890423853,
-    "wof:lastmodified":1669163720,
+    "wof:lastmodified":1690939007,
     "wof:name":"Oulad Mtaa",
     "wof:parent_id":1108784801,
     "wof:placetype":"localadmin",

--- a/data/890/423/855/890423855.geojson
+++ b/data/890/423/855/890423855.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Ouirgane"
     ],
+    "name:ceb_x_preferred":[
+        "Ouirgane"
+    ],
     "name:deu_x_preferred":[
         "Ouirgane"
     ],
@@ -57,6 +60,9 @@
         "Ouirgane"
     ],
     "name:por_x_preferred":[
+        "Ouirgane"
+    ],
+    "name:swe_x_preferred":[
         "Ouirgane"
     ],
     "name:urd_x_preferred":[
@@ -94,7 +100,7 @@
         }
     ],
     "wof:id":890423855,
-    "wof:lastmodified":1669163721,
+    "wof:lastmodified":1690939008,
     "wof:name":"Ouirgane",
     "wof:parent_id":1108784801,
     "wof:placetype":"localadmin",

--- a/data/890/423/863/890423863.geojson
+++ b/data/890/423/863/890423863.geojson
@@ -26,8 +26,14 @@
         "\u0627\u0644\u0645\u062c\u0627\u0637\u064a\u0629 \u0623\u0648\u0644\u0627\u062f \u0627\u0644\u0637\u0627\u0644\u0628",
         "\u062a\u064a\u0632\u064a \u0646\u064a\u0633\u0644\u064a"
     ],
+    "name:ary_x_preferred":[
+        "\u062a\u064a\u0632\u064a \u0646 \u0625\u064a\u0633\u0644\u064a"
+    ],
     "name:cat_x_preferred":[
         "Tizi N'Isly"
+    ],
+    "name:ceb_x_preferred":[
+        "Tizi n'Isly"
     ],
     "name:eng_x_preferred":[
         "Tizi N'Isly"
@@ -43,6 +49,12 @@
         "Isly (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Tizi N'Isly"
+    ],
+    "name:swe_x_preferred":[
+        "Tizi N'Isly"
+    ],
+    "name:uzb_x_preferred":[
         "Tizi N'Isly"
     ],
     "qs:name":"Tizi N Isly",
@@ -86,7 +98,7 @@
         }
     ],
     "wof:id":890423863,
-    "wof:lastmodified":1669156519,
+    "wof:lastmodified":1690939008,
     "wof:name":"Tizi N Isly",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/423/875/890423875.geojson
+++ b/data/890/423/875/890423875.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0633\u064a\u062f\u0649 \u0642\u0627\u0633\u0645"
     ],
+    "name:ast_x_preferred":[
+        "Sidi Kacem"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0642\u0627\u0633\u0645"
     ],
@@ -196,7 +199,7 @@
         }
     ],
     "wof:id":890423875,
-    "wof:lastmodified":1669163728,
+    "wof:lastmodified":1690938998,
     "wof:name":"Sidi-Kacem",
     "wof:parent_id":890429091,
     "wof:placetype":"localadmin",

--- a/data/890/423/879/890423879.geojson
+++ b/data/890/423/879/890423879.geojson
@@ -50,6 +50,9 @@
     "name:swe_x_preferred":[
         "Sidi Bibi"
     ],
+    "name:zho_x_preferred":[
+        "\u897f\u8fea\u6bd4\u6bd4"
+    ],
     "qs:name":"Sidi Bibi",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890423879,
-    "wof:lastmodified":1669163729,
+    "wof:lastmodified":1690939005,
     "wof:name":"Sidi Bibi",
     "wof:parent_id":1108784831,
     "wof:placetype":"localadmin",

--- a/data/890/423/893/890423893.geojson
+++ b/data/890/423/893/890423893.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Azgour"
     ],
+    "name:ceb_x_preferred":[
+        "Azgour"
+    ],
     "name:deu_x_preferred":[
         "Azgour"
     ],
@@ -51,6 +54,9 @@
         "Azgour (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Azgour"
+    ],
+    "name:swe_x_preferred":[
         "Azgour"
     ],
     "name:urd_x_preferred":[
@@ -88,7 +94,7 @@
         }
     ],
     "wof:id":890423893,
-    "wof:lastmodified":1669163731,
+    "wof:lastmodified":1690938999,
     "wof:name":"Azgour",
     "wof:parent_id":1108784801,
     "wof:placetype":"localadmin",

--- a/data/890/423/895/890423895.geojson
+++ b/data/890/423/895/890423895.geojson
@@ -66,6 +66,9 @@
     "name:swe_x_preferred":[
         "Lalla Takerkoust"
     ],
+    "name:swe_x_variant":[
+        "Lalla Takarkoust"
+    ],
     "name:urd_x_preferred":[
         "\u0644\u0627\u0644\u0627 \u0679\u0627\u06a9\u06cc\u0631\u06a9\u0648\u0633\u0679"
     ],
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":890423895,
-    "wof:lastmodified":1669163732,
+    "wof:lastmodified":1690938998,
     "wof:name":"Lalla Takarkoust",
     "wof:parent_id":1108784801,
     "wof:placetype":"localadmin",

--- a/data/890/423/899/890423899.geojson
+++ b/data/890/423/899/890423899.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Aghbar"
     ],
+    "name:ceb_x_preferred":[
+        "Aghbar"
+    ],
     "name:eng_x_preferred":[
         "Aghbar"
     ],
@@ -48,6 +51,9 @@
         "Aghbar (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Aghbar"
+    ],
+    "name:swe_x_preferred":[
         "Aghbar"
     ],
     "name:urd_x_preferred":[
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890423899,
-    "wof:lastmodified":1669163734,
+    "wof:lastmodified":1690939008,
     "wof:name":"Aghbar",
     "wof:parent_id":1108784801,
     "wof:placetype":"localadmin",

--- a/data/890/423/911/890423911.geojson
+++ b/data/890/423/911/890423911.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Imi N'Tlit"
     ],
+    "name:ceb_x_preferred":[
+        "Imi N Tlit"
+    ],
     "name:eng_x_preferred":[
         "Imi N'Tlit"
     ],
@@ -42,6 +45,9 @@
         "Imi N Tlit (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Imi N'Tlit"
+    ],
+    "name:swe_x_preferred":[
         "Imi N'Tlit"
     ],
     "qs:name":"Imi N Tlit",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890423911,
-    "wof:lastmodified":1669163739,
+    "wof:lastmodified":1690939009,
     "wof:name":"Imi N Tlit",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/423/917/890423917.geojson
+++ b/data/890/423/917/890423917.geojson
@@ -35,6 +35,9 @@
     "name:aze_x_preferred":[
         "Sahel"
     ],
+    "name:bak_x_preferred":[
+        "\u0421\u04d9\u0445\u0438\u043b"
+    ],
     "name:bel_x_preferred":[
         "\u0421\u0430\u0445\u0435\u043b\u044c"
     ],
@@ -116,6 +119,9 @@
     ],
     "name:gle_x_preferred":[
         "Saiheil"
+    ],
+    "name:gle_x_variant":[
+        "an tSaiheil"
     ],
     "name:heb_x_preferred":[
         "\u05e1\u05d0\u05d4\u05dc"
@@ -317,7 +323,7 @@
         }
     ],
     "wof:id":890423917,
-    "wof:lastmodified":1669163740,
+    "wof:lastmodified":1690939011,
     "wof:name":"Sahel",
     "wof:parent_id":890422513,
     "wof:placetype":"localadmin",

--- a/data/890/423/927/890423927.geojson
+++ b/data/890/423/927/890423927.geojson
@@ -161,6 +161,9 @@
     "name:vie_x_preferred":[
         "Tinghir"
     ],
+    "name:wln_x_preferred":[
+        "Tinrhir"
+    ],
     "name:zho_x_preferred":[
         "\u5ef7\u5409\u723e"
     ],
@@ -196,7 +199,7 @@
         }
     ],
     "wof:id":890423927,
-    "wof:lastmodified":1669163741,
+    "wof:lastmodified":1690939009,
     "wof:name":"Tinghir",
     "wof:parent_id":1108784839,
     "wof:placetype":"localadmin",

--- a/data/890/423/929/890423929.geojson
+++ b/data/890/423/929/890423929.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Had Soualem"
     ],
+    "name:ceb_x_preferred":[
+        "Soualem"
+    ],
     "name:eng_x_preferred":[
         "Soualem"
     ],
@@ -50,11 +53,17 @@
     "name:ita_x_preferred":[
         "Soualem"
     ],
+    "name:jpn_x_preferred":[
+        "\u30b9\u30a2\u30ec\u30e0"
+    ],
     "name:nld_x_preferred":[
         "Soualem"
     ],
     "name:pol_x_preferred":[
         "Soualem"
+    ],
+    "name:swe_x_preferred":[
+        "Had Soualem"
     ],
     "qs:name":"Soualem",
     "qs:photos_9r":0,
@@ -88,7 +97,7 @@
         }
     ],
     "wof:id":890423929,
-    "wof:lastmodified":1669163742,
+    "wof:lastmodified":1690939009,
     "wof:name":"Soualem",
     "wof:parent_id":1108784793,
     "wof:placetype":"localadmin",

--- a/data/890/423/935/890423935.geojson
+++ b/data/890/423/935/890423935.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Ait Taguella"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Taguella"
+    ],
     "name:eng_x_preferred":[
         "Ait Taguella"
     ],
@@ -45,6 +48,12 @@
         "Ait Taguella (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Ait Taguella"
+    ],
+    "name:swe_x_preferred":[
+        "Ait Taguella"
+    ],
+    "name:uzb_x_preferred":[
         "Ait Taguella"
     ],
     "qs:name":"Ait Taguella",
@@ -79,7 +88,7 @@
         }
     ],
     "wof:id":890423935,
-    "wof:lastmodified":1669163745,
+    "wof:lastmodified":1690939003,
     "wof:name":"Ait Taguella",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/423/945/890423945.geojson
+++ b/data/890/423/945/890423945.geojson
@@ -53,6 +53,9 @@
     "name:ita_x_preferred":[
         "Bni Oukil"
     ],
+    "name:uzb_x_preferred":[
+        "Bni Oukil"
+    ],
     "qs:name":"Bni Oukil",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890423945,
-    "wof:lastmodified":1669163749,
+    "wof:lastmodified":1690939010,
     "wof:name":"Bni Oukil",
     "wof:parent_id":1108784787,
     "wof:placetype":"localadmin",

--- a/data/890/423/949/890423949.geojson
+++ b/data/890/423/949/890423949.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0632\u0627\u064a\u0648"
     ],
+    "name:ast_x_preferred":[
+        "Zaio"
+    ],
     "name:azb_x_preferred":[
         "\u0632\u0627\u06cc\u0648"
     ],
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890423949,
-    "wof:lastmodified":1669163749,
+    "wof:lastmodified":1690939001,
     "wof:name":"Zaio",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/423/957/890423957.geojson
+++ b/data/890/423/957/890423957.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Aoulouz"
     ],
+    "name:ceb_x_preferred":[
+        "Aoulouz"
+    ],
     "name:deu_x_preferred":[
         "Aoulouz"
     ],
@@ -58,6 +61,9 @@
     ],
     "name:shi_x_preferred":[
         "Awluz"
+    ],
+    "name:swe_x_preferred":[
+        "Aoulouz"
     ],
     "name:zho_x_preferred":[
         "\u5965\u5362\u5179"
@@ -94,7 +100,7 @@
         }
     ],
     "wof:id":890423957,
-    "wof:lastmodified":1669163752,
+    "wof:lastmodified":1690939002,
     "wof:name":"Aoulouz",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/423/963/890423963.geojson
+++ b/data/890/423/963/890423963.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Iguidi"
     ],
+    "name:ceb_x_preferred":[
+        "Iguidi"
+    ],
     "name:eng_x_preferred":[
         "Iguidi"
     ],
@@ -42,6 +45,9 @@
         "Iguidi (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Iguidi"
+    ],
+    "name:swe_x_preferred":[
         "Iguidi"
     ],
     "qs:name":"Iguidi",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890423963,
-    "wof:lastmodified":1669163755,
+    "wof:lastmodified":1690938996,
     "wof:name":"Iguidi",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/423/975/890423975.geojson
+++ b/data/890/423/975/890423975.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Anjra"
     ],
+    "name:ceb_x_preferred":[
+        "Anjra"
+    ],
     "name:eng_x_preferred":[
         "Anjra"
     ],
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":890423975,
-    "wof:lastmodified":1669163759,
+    "wof:lastmodified":1690939011,
     "wof:name":"Anjra",
     "wof:parent_id":890442529,
     "wof:placetype":"localadmin",

--- a/data/890/423/981/890423981.geojson
+++ b/data/890/423/981/890423981.geojson
@@ -31,7 +31,13 @@
     "name:azb_x_preferred":[
         "\u062a\u0627\u0632\u0646\u0627\u062e\u062a"
     ],
+    "name:bul_x_preferred":[
+        "\u0422\u0430\u0437\u043d\u0430\u043a\u0445\u0442"
+    ],
     "name:cat_x_preferred":[
+        "Taznakht"
+    ],
+    "name:ceb_x_preferred":[
         "Taznakht"
     ],
     "name:deu_x_preferred":[
@@ -59,6 +65,9 @@
     ],
     "name:nld_x_preferred":[
         "Tazenakht"
+    ],
+    "name:swe_x_preferred":[
+        "Taznakht"
     ],
     "name:zho_x_preferred":[
         "\u6cf0\u8332\u7d0d\u8d6b\u7279"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":890423981,
-    "wof:lastmodified":1669163762,
+    "wof:lastmodified":1690939011,
     "wof:name":"Taznakht",
     "wof:parent_id":1108784843,
     "wof:placetype":"localadmin",

--- a/data/890/423/983/890423983.geojson
+++ b/data/890/423/983/890423983.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Talambote"
     ],
+    "name:ceb_x_preferred":[
+        "Talambote"
+    ],
     "name:eng_x_preferred":[
         "Talambote"
     ],
@@ -46,6 +49,9 @@
     ],
     "name:spa_x_preferred":[
         "Talambot"
+    ],
+    "name:swe_x_preferred":[
+        "Talambote"
     ],
     "name:urd_x_preferred":[
         "\u062a\u0627\u0644\u0645\u0628\u0648\u0637"
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":890423983,
-    "wof:lastmodified":1669163762,
+    "wof:lastmodified":1690939000,
     "wof:name":"Talambote",
     "wof:parent_id":890453883,
     "wof:placetype":"localadmin",

--- a/data/890/423/995/890423995.geojson
+++ b/data/890/423/995/890423995.geojson
@@ -180,6 +180,9 @@
     "name:nob_x_preferred":[
         "T\u00e9touan"
     ],
+    "name:oci_x_preferred":[
+        "Tetoan"
+    ],
     "name:pol_x_preferred":[
         "Tetuan"
     ],
@@ -298,7 +301,7 @@
         }
     ],
     "wof:id":890423995,
-    "wof:lastmodified":1669163765,
+    "wof:lastmodified":1690939002,
     "wof:name":"Tetouan",
     "wof:parent_id":890421483,
     "wof:placetype":"localadmin",

--- a/data/890/424/017/890424017.geojson
+++ b/data/890/424/017/890424017.geojson
@@ -52,6 +52,9 @@
     "name:ceb_x_preferred":[
         "Ksar el Kebir"
     ],
+    "name:ces_x_preferred":[
+        "Ksar Al Kebir"
+    ],
     "name:dan_x_preferred":[
         "Ksar el-K\u00e9bir"
     ],
@@ -221,7 +224,7 @@
         }
     ],
     "wof:id":890424017,
-    "wof:lastmodified":1669163769,
+    "wof:lastmodified":1690938991,
     "wof:name":"Ksar El Kebir",
     "wof:parent_id":890422513,
     "wof:placetype":"localadmin",

--- a/data/890/424/019/890424019.geojson
+++ b/data/890/424/019/890424019.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0633\u064a\u062f\u0649 \u0628\u0648\u0642\u0646\u0627\u062f\u0644"
     ],
+    "name:ast_x_preferred":[
+        "Bouknadel"
+    ],
     "name:bul_x_preferred":[
         "\u0411\u043e\u0443\u043a\u043d\u0430\u0434\u0435\u043b"
     ],
@@ -66,6 +69,9 @@
     "name:swe_x_preferred":[
         "Bouknadel"
     ],
+    "name:swe_x_variant":[
+        "Sidi Bouknadel"
+    ],
     "qs:name":"Bouknadel",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":890424019,
-    "wof:lastmodified":1669163770,
+    "wof:lastmodified":1690938991,
     "wof:name":"Bouknadel",
     "wof:parent_id":1108784811,
     "wof:placetype":"localadmin",

--- a/data/890/424/029/890424029.geojson
+++ b/data/890/424/029/890424029.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "Tnine Aglou"
     ],
+    "name:eng_x_variant":[
+        "Aglou"
+    ],
     "name:fra_x_preferred":[
         "Tnine Aglou"
     ],
@@ -59,6 +62,9 @@
     ],
     "name:swe_x_preferred":[
         "Tnine Aglou"
+    ],
+    "name:swe_x_variant":[
+        "Aglou"
     ],
     "qs:name":"Tnine Aglou",
     "qs:photos_9r":0,
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":890424029,
-    "wof:lastmodified":1669163773,
+    "wof:lastmodified":1690938990,
     "wof:name":"Tnine Aglou",
     "wof:parent_id":890428801,
     "wof:placetype":"localadmin",

--- a/data/890/424/031/890424031.geojson
+++ b/data/890/424/031/890424031.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_variant":[
         "\u0633\u064a\u062f\u064a \u063a\u0627\u0646\u0645"
     ],
+    "name:ary_x_preferred":[
+        "\u0633\u064a\u062f\u064a \u063a\u0627\u0646\u0645"
+    ],
     "name:cat_x_preferred":[
         "Sidi Ghaneme"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":890424031,
-    "wof:lastmodified":1669158655,
+    "wof:lastmodified":1690938987,
     "wof:name":"Sidi Ghaneme",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/424/037/890424037.geojson
+++ b/data/890/424/037/890424037.geojson
@@ -56,6 +56,9 @@
     "name:swe_x_preferred":[
         "Boulanouare"
     ],
+    "name:uzb_x_preferred":[
+        "Boulanouare"
+    ],
     "qs:name":"Boulanouare",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890424037,
-    "wof:lastmodified":1669163773,
+    "wof:lastmodified":1690938988,
     "wof:name":"Boulanouare",
     "wof:parent_id":890422519,
     "wof:placetype":"localadmin",

--- a/data/890/424/047/890424047.geojson
+++ b/data/890/424/047/890424047.geojson
@@ -50,6 +50,9 @@
     "name:swe_x_preferred":[
         "Dar Chaffai"
     ],
+    "name:swe_x_variant":[
+        "Dar Chaffa\u00ef"
+    ],
     "qs:name":"Dar Chaffai",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890424047,
-    "wof:lastmodified":1669163776,
+    "wof:lastmodified":1690938987,
     "wof:name":"Dar Chaffai",
     "wof:parent_id":1108784833,
     "wof:placetype":"localadmin",

--- a/data/890/424/053/890424053.geojson
+++ b/data/890/424/053/890424053.geojson
@@ -28,6 +28,9 @@
     "name:cat_x_preferred":[
         "Oulad Amer"
     ],
+    "name:ceb_x_preferred":[
+        "Oulad Amer"
+    ],
     "name:eng_x_preferred":[
         "Oulad Amer"
     ],
@@ -39,6 +42,9 @@
         "Oulad Amer (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Oulad Amer"
+    ],
+    "name:swe_x_preferred":[
         "Oulad Amer"
     ],
     "qs:name":"Oulad Amer",
@@ -73,7 +79,7 @@
         }
     ],
     "wof:id":890424053,
-    "wof:lastmodified":1669156897,
+    "wof:lastmodified":1690938987,
     "wof:name":"Oulad Amer",
     "wof:parent_id":1108784833,
     "wof:placetype":"localadmin",

--- a/data/890/424/071/890424071.geojson
+++ b/data/890/424/071/890424071.geojson
@@ -40,6 +40,9 @@
     "name:aze_x_preferred":[
         "M\u0259h\u0259mm\u0259diyy\u0259"
     ],
+    "name:bel_x_preferred":[
+        "\u041c\u0430\u0445\u0430\u043c\u0435\u0434\u044b\u044f"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09cb\u09b9\u09be\u09ae\u09cd\u09ae\u09be\u09a6\u09bf\u09af\u09bc\u09be"
     ],
@@ -104,6 +107,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d5\u30a7\u30c9\u30cf\u30e9\uff08\u30e2\u30cf\u30e1\u30c7\u30a3\u30a2\uff09"
+    ],
+    "name:jpn_x_variant":[
+        "\u30e2\u30cf\u30e1\u30c7\u30a3\u30a2"
     ],
     "name:kab_x_preferred":[
         "Mu\u1e25emmedeyya"
@@ -233,7 +239,7 @@
         }
     ],
     "wof:id":890424071,
-    "wof:lastmodified":1669163781,
+    "wof:lastmodified":1690938986,
     "wof:name":"Mohammedia",
     "wof:parent_id":890424147,
     "wof:placetype":"localadmin",

--- a/data/890/424/077/890424077.geojson
+++ b/data/890/424/077/890424077.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Tiffert N'Ait Hamza"
     ],
+    "name:ceb_x_preferred":[
+        "Tiffert N Ait Hamza"
+    ],
     "name:eng_x_preferred":[
         "Tiffert N'Ait Hamza"
     ],
@@ -44,6 +47,9 @@
     ],
     "name:ita_x_preferred":[
         "Tiffert N'Ait Hamza"
+    ],
+    "name:swe_x_preferred":[
+        "Tiffert N Ait Hamza"
     ],
     "qs:name":"Tiffert N Ait Hamza",
     "qs:photos_9r":0,
@@ -77,7 +83,7 @@
         }
     ],
     "wof:id":890424077,
-    "wof:lastmodified":1669163783,
+    "wof:lastmodified":1690938986,
     "wof:name":"Tiffert N Ait Hamza",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/424/079/890424079.geojson
+++ b/data/890/424/079/890424079.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0628\u0646\u0649 \u0645\u0644\u0627\u0644"
     ],
+    "name:ast_x_preferred":[
+        "Beni Mellal"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646\u06cc\u200c\u0645\u0644\u0627\u0644"
     ],
@@ -41,6 +44,9 @@
         "Beni Mellal"
     ],
     "name:ceb_x_preferred":[
+        "Beni Mellal"
+    ],
+    "name:ces_x_preferred":[
         "Beni Mellal"
     ],
     "name:cym_x_preferred":[
@@ -212,7 +218,7 @@
         }
     ],
     "wof:id":890424079,
-    "wof:lastmodified":1669163783,
+    "wof:lastmodified":1690938985,
     "wof:name":"Beni Mellal",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/424/083/890424083.geojson
+++ b/data/890/424/083/890424083.geojson
@@ -56,6 +56,9 @@
     "name:swe_x_preferred":[
         "El Ksiba"
     ],
+    "name:uzb_x_preferred":[
+        "El Ksiba"
+    ],
     "qs:name":"El Ksiba",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890424083,
-    "wof:lastmodified":1669163784,
+    "wof:lastmodified":1690938986,
     "wof:name":"El Ksiba",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/424/101/890424101.geojson
+++ b/data/890/424/101/890424101.geojson
@@ -59,6 +59,9 @@
     "name:swe_x_preferred":[
         "Mechra Bel Ksiri"
     ],
+    "name:swe_x_variant":[
+        "Mechraa Bel Ksiri"
+    ],
     "qs:name":"Mechra Bel Ksiri",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890424101,
-    "wof:lastmodified":1669163789,
+    "wof:lastmodified":1690938990,
     "wof:name":"Mechra Bel Ksiri",
     "wof:parent_id":890429091,
     "wof:placetype":"localadmin",

--- a/data/890/424/103/890424103.geojson
+++ b/data/890/424/103/890424103.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Moulay Abdelkader"
     ],
+    "name:ceb_x_preferred":[
+        "Moulay Abdelkader"
+    ],
     "name:eng_x_preferred":[
         "Moulay Abdelkader"
     ],
@@ -42,6 +45,9 @@
         "Moulay Abdelkader (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Moulay Abdelkader"
+    ],
+    "name:swe_x_preferred":[
         "Moulay Abdelkader"
     ],
     "qs:name":"Moulay Abdelkader",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890424103,
-    "wof:lastmodified":1669163790,
+    "wof:lastmodified":1690938984,
     "wof:name":"Moulay Abdelkader",
     "wof:parent_id":890429091,
     "wof:placetype":"localadmin",

--- a/data/890/424/113/890424113.geojson
+++ b/data/890/424/113/890424113.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Ain Aicha"
     ],
+    "name:ceb_x_preferred":[
+        "Ain Aicha"
+    ],
     "name:eng_x_preferred":[
         "A\u00efn A\u00efcha"
     ],
@@ -44,6 +47,9 @@
     ],
     "name:ita_x_preferred":[
         "A\u00efn A\u00efcha"
+    ],
+    "name:swe_x_preferred":[
+        "Ain Aicha"
     ],
     "qs:name":"Ain Aicha",
     "qs:photos_9r":0,
@@ -77,7 +83,7 @@
         }
     ],
     "wof:id":890424113,
-    "wof:lastmodified":1669163794,
+    "wof:lastmodified":1690938993,
     "wof:name":"Ain Aicha",
     "wof:parent_id":890418103,
     "wof:placetype":"localadmin",

--- a/data/890/424/145/890424145.geojson
+++ b/data/890/424/145/890424145.geojson
@@ -91,6 +91,12 @@
     "name:spa_x_preferred":[
         "Provincia de Nouaceur"
     ],
+    "name:swe_x_preferred":[
+        "Nouaceur"
+    ],
+    "name:tur_x_preferred":[
+        "Nevasir"
+    ],
     "name:urd_x_preferred":[
         "\u0635\u0648\u0628\u06c1 \u0646\u0648\u0627\u0635\u0631"
     ],
@@ -149,7 +155,7 @@
         }
     ],
     "wof:id":890424145,
-    "wof:lastmodified":1669163804,
+    "wof:lastmodified":1690938988,
     "wof:name":"Nouaceur",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/424/147/890424147.geojson
+++ b/data/890/424/147/890424147.geojson
@@ -86,6 +86,9 @@
     "name:spa_x_preferred":[
         "Mohammed\u00eda"
     ],
+    "name:tur_x_preferred":[
+        "Muhammediye"
+    ],
     "name:und_x_variant":[
         "Al-Mu\u1e25ammadia"
     ],
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":890424147,
-    "wof:lastmodified":1669163805,
+    "wof:lastmodified":1690938993,
     "wof:name":"Mohammedia",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/424/149/890424149.geojson
+++ b/data/890/424/149/890424149.geojson
@@ -97,6 +97,12 @@
     "name:spa_x_preferred":[
         "Provincia de Zagora"
     ],
+    "name:swe_x_preferred":[
+        "Zagora"
+    ],
+    "name:tur_x_preferred":[
+        "Zakura"
+    ],
     "name:zho_x_preferred":[
         "\u624e\u53e4\u62c9\u7701"
     ],
@@ -150,7 +156,7 @@
         }
     ],
     "wof:id":890424149,
-    "wof:lastmodified":1669163817,
+    "wof:lastmodified":1690938993,
     "wof:name":"Zagora",
     "wof:parent_id":1796661363,
     "wof:placetype":"county",

--- a/data/890/424/151/890424151.geojson
+++ b/data/890/424/151/890424151.geojson
@@ -92,6 +92,12 @@
     "name:spa_x_preferred":[
         "Provincia de Mediuna"
     ],
+    "name:swe_x_preferred":[
+        "M\u00e9diouna"
+    ],
+    "name:tur_x_preferred":[
+        "Medyuna"
+    ],
     "name:zho_x_preferred":[
         "\u6885\u4e45\u90a3\u7701"
     ],
@@ -145,7 +151,7 @@
         }
     ],
     "wof:id":890424151,
-    "wof:lastmodified":1669163818,
+    "wof:lastmodified":1690938985,
     "wof:name":"Mediouna",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/427/533/890427533.geojson
+++ b/data/890/427/533/890427533.geojson
@@ -54,6 +54,9 @@
     "name:arz_x_preferred":[
         "\u062e\u0646\u064a\u0641\u0631\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Khenifra"
+    ],
     "name:azb_x_preferred":[
         "\u062e\u0646\u06cc\u0641\u0631\u0647"
     ],
@@ -252,7 +255,7 @@
         }
     ],
     "wof:id":890427533,
-    "wof:lastmodified":1669163833,
+    "wof:lastmodified":1690939097,
     "wof:name":"Kenitra",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/890/428/801/890428801.geojson
+++ b/data/890/428/801/890428801.geojson
@@ -106,6 +106,9 @@
     "name:swe_x_preferred":[
         "Tiznit"
     ],
+    "name:tur_x_preferred":[
+        "Tiznit"
+    ],
     "name:und_x_variant":[
         "\u0625\u0642\u0644\u064a\u0645 \u062a\u0632\u0646\u064a\u062a",
         "Igl\u012bm Tizn\u012bt"
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":890428801,
-    "wof:lastmodified":1669163856,
+    "wof:lastmodified":1690939047,
     "wof:name":"Tiznit",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/890/429/091/890429091.geojson
+++ b/data/890/429/091/890429091.geojson
@@ -98,6 +98,12 @@
     "name:swe_x_preferred":[
         "Sidi-Kacem"
     ],
+    "name:swe_x_variant":[
+        "Sidi Kacem"
+    ],
+    "name:tur_x_preferred":[
+        "Sidi Kas\u0131m"
+    ],
     "name:urd_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0642\u0627\u0633\u0645 \u0635\u0648\u0628\u06c1"
     ],
@@ -156,7 +162,7 @@
         }
     ],
     "wof:id":890429091,
-    "wof:lastmodified":1669163867,
+    "wof:lastmodified":1690939068,
     "wof:name":"Sidi Kacem",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/890/429/093/890429093.geojson
+++ b/data/890/429/093/890429093.geojson
@@ -101,6 +101,12 @@
     "name:swe_x_preferred":[
         "Inezgane-Ait Mellou"
     ],
+    "name:swe_x_variant":[
+        "Inezgane-A\u00eft Melloul"
+    ],
+    "name:tur_x_preferred":[
+        "\u0130nziken-Eyt Melul"
+    ],
     "name:urd_x_preferred":[
         "\u0627\u0646\u0632\u06a9\u0627\u0646 \u0622\u06cc\u062a \u0645\u0644\u0648\u0644"
     ],
@@ -155,7 +161,7 @@
         }
     ],
     "wof:id":890429093,
-    "wof:lastmodified":1669163870,
+    "wof:lastmodified":1690939070,
     "wof:name":"Inezgane-Ait Melloul",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/890/429/095/890429095.geojson
+++ b/data/890/429/095/890429095.geojson
@@ -100,6 +100,9 @@
     "name:swe_x_preferred":[
         "Ifrane"
     ],
+    "name:tur_x_preferred":[
+        "\u0130fran"
+    ],
     "name:ukr_x_preferred":[
         "\u0406\u0444\u0440\u0430\u043d"
     ],
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":890429095,
-    "wof:lastmodified":1669163873,
+    "wof:lastmodified":1690939070,
     "wof:name":"Ifrane",
     "wof:parent_id":1796661365,
     "wof:placetype":"county",

--- a/data/890/429/097/890429097.geojson
+++ b/data/890/429/097/890429097.geojson
@@ -78,6 +78,9 @@
     "name:eng_x_variant":[
         "Al Hoce\u00efma Province"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0633\u062a\u0627\u0646 \u062d\u0633\u06cc\u0645\u0647"
+    ],
     "name:fra_x_preferred":[
         "Al-Hoceima"
     ],
@@ -109,6 +112,12 @@
     ],
     "name:swe_x_preferred":[
         "Al-Hoceima"
+    ],
+    "name:swe_x_variant":[
+        "Al Hoce\u00efma"
+    ],
+    "name:tur_x_preferred":[
+        "El-H\u00fcseyma"
     ],
     "name:und_x_variant":[
         "Rif"
@@ -169,7 +178,7 @@
         }
     ],
     "wof:id":890429097,
-    "wof:lastmodified":1669163887,
+    "wof:lastmodified":1690939069,
     "wof:name":"Al Hoceima",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/890/429/099/890429099.geojson
+++ b/data/890/429/099/890429099.geojson
@@ -61,6 +61,9 @@
     "name:cat_x_variant":[
         "prefectura d'Agadir Ida-Outanane"
     ],
+    "name:ceb_x_preferred":[
+        "Agadir-Ida-ou-Tnan"
+    ],
     "name:deu_x_preferred":[
         "Agadir-Ida ou Tanane"
     ],
@@ -98,6 +101,12 @@
     ],
     "name:spa_x_preferred":[
         "Prefectura de Agadir Ida-Outanane"
+    ],
+    "name:swe_x_preferred":[
+        "Agadir-Ida-Ou-Tanane"
+    ],
+    "name:tur_x_preferred":[
+        "Agadir \u0130da-Vatnan"
     ],
     "name:und_x_variant":[
         "Igli\u012bm Ag\u0101di\u012br"
@@ -150,7 +159,7 @@
         }
     ],
     "wof:id":890429099,
-    "wof:lastmodified":1669163897,
+    "wof:lastmodified":1690939069,
     "wof:name":"Agadir Ida-Outanane",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/890/429/101/890429101.geojson
+++ b/data/890/429/101/890429101.geojson
@@ -48,6 +48,9 @@
     "name:cat_x_preferred":[
         "Prefectura de Skhirate-T\u00e9mara"
     ],
+    "name:ceb_x_preferred":[
+        "Skhirate-Temara"
+    ],
     "name:deu_x_preferred":[
         "Skhirate-T\u00e9mara"
     ],
@@ -79,6 +82,12 @@
     ],
     "name:spa_x_preferred":[
         "Prefectura de Sjirat-T\u00e9mara"
+    ],
+    "name:swe_x_preferred":[
+        "Skhirate-T\u00e9mara"
+    ],
+    "name:tur_x_preferred":[
+        "Suheyre-Timara"
     ],
     "name:und_x_variant":[
         "\u0639\u0645\u0627\u0644\u0629 \u0627\u0644\u0635\u062e\u064a\u0631\u0627\u062a-\u062a\u0645\u0627\u0631\u0629",
@@ -135,7 +144,7 @@
         }
     ],
     "wof:id":890429101,
-    "wof:lastmodified":1669163901,
+    "wof:lastmodified":1690939069,
     "wof:name":"Skhirate-Temara",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/890/432/371/890432371.geojson
+++ b/data/890/432/371/890432371.geojson
@@ -35,6 +35,9 @@
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0627\u0641\u0646\u06cc"
     ],
+    "name:bel_x_preferred":[
+        "\u0421\u0456\u0434\u0437\u0456-\u0406\u0444\u043d\u0456"
+    ],
     "name:bul_x_preferred":[
         "\u0421\u0438\u0434\u0438 \u0418\u0444\u043d\u0438"
     ],
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":890432371,
-    "wof:lastmodified":1669163902,
+    "wof:lastmodified":1690939105,
     "wof:name":"Sidi Ifni",
     "wof:parent_id":1108784841,
     "wof:placetype":"locality",

--- a/data/890/432/373/890432373.geojson
+++ b/data/890/432/373/890432373.geojson
@@ -29,6 +29,9 @@
     "name:arz_x_preferred":[
         "\u0633\u064a\u062f\u0649 \u0628\u0646\u0648\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Sidi Bennour"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0628\u0646\u0648\u0631"
     ],
@@ -56,6 +59,9 @@
     "name:eng_x_preferred":[
         "Sidi Bennour"
     ],
+    "name:eng_x_variant":[
+        "el jadida"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0628\u0646\u0648\u0631"
     ],
@@ -76,6 +82,12 @@
     ],
     "name:jpn_x_variant":[
         "\u30b7\u30c7\u30a3 \u30d9\u30ce\u30fc\u30eb"
+    ],
+    "name:mlt_x_preferred":[
+        "Sidi Bennour"
+    ],
+    "name:msa_x_preferred":[
+        "Sidi Bennour"
     ],
     "name:nan_x_preferred":[
         "Sidi Bennour"
@@ -159,7 +171,7 @@
         }
     ],
     "wof:id":890432373,
-    "wof:lastmodified":1669163903,
+    "wof:lastmodified":1690939106,
     "wof:name":"Sidi Bennour",
     "wof:parent_id":1108784819,
     "wof:placetype":"locality",

--- a/data/890/434/661/890434661.geojson
+++ b/data/890/434/661/890434661.geojson
@@ -37,6 +37,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627\u0621"
     ],
+    "name:arq_x_preferred":[
+        "\u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627"
+    ],
     "name:ary_x_preferred":[
         "\u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627"
     ],
@@ -578,7 +581,7 @@
         }
     ],
     "wof:id":890434661,
-    "wof:lastmodified":1669163905,
+    "wof:lastmodified":1690939105,
     "wof:megacity":1,
     "wof:name":"Casablanca",
     "wof:parent_id":890442533,

--- a/data/890/434/669/890434669.geojson
+++ b/data/890/434/669/890434669.geojson
@@ -29,6 +29,9 @@
     "name:arz_x_preferred":[
         "\u062a\u0627\u0648\u0631\u064a\u0631\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Taourirt"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0627\u0648\u0631\u06cc\u0631\u062a"
     ],
@@ -207,7 +210,7 @@
         }
     ],
     "wof:id":890434669,
-    "wof:lastmodified":1669163906,
+    "wof:lastmodified":1690939105,
     "wof:name":"Taourirt",
     "wof:parent_id":1108784813,
     "wof:placetype":"locality",

--- a/data/890/435/383/890435383.geojson
+++ b/data/890/435/383/890435383.geojson
@@ -172,6 +172,9 @@
     "name:mar_x_preferred":[
         "\u092e\u0947\u0915\u0928\u0947\u0938"
     ],
+    "name:mdf_x_preferred":[
+        "\u041c\u044d\u043a\u043d\u044d\u0441"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u0435\u043a\u043d\u0435\u0441"
     ],
@@ -422,7 +425,7 @@
         }
     ],
     "wof:id":890435383,
-    "wof:lastmodified":1669163908,
+    "wof:lastmodified":1690939107,
     "wof:name":"Mekn\u00e8s",
     "wof:parent_id":1108784837,
     "wof:placetype":"locality",

--- a/data/890/435/387/890435387.geojson
+++ b/data/890/435/387/890435387.geojson
@@ -67,6 +67,9 @@
     "name:bos_x_variant":[
         "Marrakech"
     ],
+    "name:bre_x_preferred":[
+        "Marrakech"
+    ],
     "name:bul_x_preferred":[
         "\u041c\u0430\u0440\u0430\u043a\u0435\u0448"
     ],
@@ -229,8 +232,14 @@
     "name:mar_x_preferred":[
         "\u092e\u093e\u0930\u093e\u0915\u0947\u0936"
     ],
+    "name:mdf_x_preferred":[
+        "\u041c\u0430\u0440\u0440\u0430\u043a\u044d\u0448"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u0430\u0440\u0430\u043a\u0435\u0448"
+    ],
+    "name:mlt_x_preferred":[
+        "Marrakesh"
     ],
     "name:msa_x_preferred":[
         "Marrakesh"
@@ -529,7 +538,7 @@
         }
     ],
     "wof:id":890435387,
-    "wof:lastmodified":1669163909,
+    "wof:lastmodified":1690939109,
     "wof:megacity":1,
     "wof:name":"Marrakesh",
     "wof:parent_id":1108784829,

--- a/data/890/435/525/890435525.geojson
+++ b/data/890/435/525/890435525.geojson
@@ -177,6 +177,9 @@
     "name:mar_x_preferred":[
         "\u092e\u0947\u0915\u0928\u0947\u0938"
     ],
+    "name:mdf_x_preferred":[
+        "\u041c\u044d\u043a\u043d\u044d\u0441"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u0435\u043a\u043d\u0435\u0441"
     ],
@@ -322,7 +325,7 @@
         }
     ],
     "wof:id":890435525,
-    "wof:lastmodified":1669163913,
+    "wof:lastmodified":1690939109,
     "wof:name":"Meknes",
     "wof:parent_id":1108784837,
     "wof:placetype":"localadmin",

--- a/data/890/435/531/890435531.geojson
+++ b/data/890/435/531/890435531.geojson
@@ -59,6 +59,9 @@
     "name:swe_x_preferred":[
         "Boutferda"
     ],
+    "name:uzb_x_preferred":[
+        "Boutferda"
+    ],
     "qs:name":"Boutferda",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890435531,
-    "wof:lastmodified":1669163915,
+    "wof:lastmodified":1690939108,
     "wof:name":"Boutferda",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/435/541/890435541.geojson
+++ b/data/890/435/541/890435541.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "M'Ramer"
     ],
+    "name:ceb_x_preferred":[
+        "M Ramer"
+    ],
     "name:eng_x_preferred":[
         "M'Ramer"
     ],
@@ -42,6 +45,9 @@
         "M Ramer (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "M'Ramer"
+    ],
+    "name:swe_x_preferred":[
         "M'Ramer"
     ],
     "qs:name":"M Ramer",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890435541,
-    "wof:lastmodified":1669163917,
+    "wof:lastmodified":1690939109,
     "wof:name":"M Ramer",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/435/543/890435543.geojson
+++ b/data/890/435/543/890435543.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Oulad M'Rabet"
     ],
+    "name:ceb_x_preferred":[
+        "Oulad M Rabet"
+    ],
     "name:eng_x_preferred":[
         "Oulad M'Rabet"
     ],
@@ -46,6 +49,9 @@
         "Oulad M'Rabet"
     ],
     "name:spa_x_preferred":[
+        "Oulad M'Rabet"
+    ],
+    "name:swe_x_preferred":[
         "Oulad M'Rabet"
     ],
     "qs:name":"Oulad M Rabet",
@@ -80,7 +86,7 @@
         }
     ],
     "wof:id":890435543,
-    "wof:lastmodified":1669163918,
+    "wof:lastmodified":1690939107,
     "wof:name":"Oulad M Rabet",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/435/553/890435553.geojson
+++ b/data/890/435/553/890435553.geojson
@@ -52,7 +52,8 @@
     "name:fra_x_variant":[
         "Laattaouia (MU)",
         "Laattaouia (Commune Urbaine)",
-        "El Attaouia"
+        "El Attaouia",
+        "La\u00e2ttaouia"
     ],
     "name:ita_x_preferred":[
         "El Attaouia"
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":890435553,
-    "wof:lastmodified":1669163922,
+    "wof:lastmodified":1690939108,
     "wof:name":"Laattaouia",
     "wof:parent_id":1108784785,
     "wof:placetype":"localadmin",

--- a/data/890/436/419/890436419.geojson
+++ b/data/890/436/419/890436419.geojson
@@ -94,6 +94,9 @@
     "name:swe_x_preferred":[
         "Boulemane"
     ],
+    "name:tur_x_preferred":[
+        "Bulman"
+    ],
     "name:und_x_variant":[
         "Province de Boulmane"
     ],
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":890436419,
-    "wof:lastmodified":1669163931,
+    "wof:lastmodified":1690939028,
     "wof:name":"Boulemane",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/436/421/890436421.geojson
+++ b/data/890/436/421/890436421.geojson
@@ -91,6 +91,9 @@
     "name:swe_x_preferred":[
         "Benslimane"
     ],
+    "name:tur_x_preferred":[
+        "Bin S\u00fcleyman"
+    ],
     "name:und_x_variant":[
         "\u0625\u0642\u0644\u064a\u0645 \u0628\u0646 \u0633\u0644\u064a\u0645\u0627\u0646",
         "Igl\u012bm Ibn Sulaym\u0101n"
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890436421,
-    "wof:lastmodified":1669163942,
+    "wof:lastmodified":1690939028,
     "wof:name":"Benslimane",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/436/467/890436467.geojson
+++ b/data/890/436/467/890436467.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0642\u0644\u064a\u0639\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Lqli\u00e2a"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0644\u06cc\u0639\u0647"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:ceb_x_preferred":[
         "Lqliaa"
+    ],
+    "name:deu_x_preferred":[
+        "Lqli\u00e2a"
     ],
     "name:eng_x_preferred":[
         "Lqli\u00e2a"
@@ -112,7 +118,7 @@
         }
     ],
     "wof:id":890436467,
-    "wof:lastmodified":1669163949,
+    "wof:lastmodified":1690939029,
     "wof:name":"Lqliaa",
     "wof:parent_id":890429093,
     "wof:placetype":"localadmin",

--- a/data/890/436/471/890436471.geojson
+++ b/data/890/436/471/890436471.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u062a\u0645\u0633\u064a\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Temsia"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0645\u0633\u06cc\u0647"
     ],
@@ -41,6 +44,9 @@
         "Temsia"
     ],
     "name:ceb_x_preferred":[
+        "Temsia"
+    ],
+    "name:deu_x_preferred":[
         "Temsia"
     ],
     "name:eng_x_preferred":[
@@ -108,7 +114,7 @@
         }
     ],
     "wof:id":890436471,
-    "wof:lastmodified":1669163950,
+    "wof:lastmodified":1690939025,
     "wof:name":"Temsia",
     "wof:parent_id":890429093,
     "wof:placetype":"localadmin",

--- a/data/890/436/477/890436477.geojson
+++ b/data/890/436/477/890436477.geojson
@@ -54,6 +54,9 @@
     "name:swe_x_preferred":[
         "Ida Ou ga\u00eflal"
     ],
+    "name:swe_x_variant":[
+        "Ida Ou Gailal"
+    ],
     "qs:name":"Ida Ou Gailal",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":890436477,
-    "wof:lastmodified":1669163953,
+    "wof:lastmodified":1690939026,
     "wof:name":"Ida Ou Gailal",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/436/479/890436479.geojson
+++ b/data/890/436/479/890436479.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0641\u0631\u0627\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Ifrane"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0641\u0631\u0627\u0646"
     ],
@@ -79,6 +82,9 @@
     ],
     "name:lit_x_preferred":[
         "Ifranas"
+    ],
+    "name:msa_x_preferred":[
+        "Ifrane"
     ],
     "name:nah_x_preferred":[
         "Ifrane"
@@ -153,7 +159,7 @@
         }
     ],
     "wof:id":890436479,
-    "wof:lastmodified":1669163954,
+    "wof:lastmodified":1690939026,
     "wof:name":"Ifrane",
     "wof:parent_id":890429095,
     "wof:placetype":"localadmin",

--- a/data/890/436/491/890436491.geojson
+++ b/data/890/436/491/890436491.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Tissaf"
     ],
+    "name:ceb_x_preferred":[
+        "Tissaf"
+    ],
     "name:eng_x_preferred":[
         "Tissaf"
     ],
@@ -42,6 +45,9 @@
         "Tissaf (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Tissaf"
+    ],
+    "name:swe_x_preferred":[
         "Tissaf"
     ],
     "qs:name":"Tissaf",
@@ -84,7 +90,7 @@
         }
     ],
     "wof:id":890436491,
-    "wof:lastmodified":1669163957,
+    "wof:lastmodified":1690939027,
     "wof:name":"Tissaf",
     "wof:parent_id":890436419,
     "wof:placetype":"localadmin",

--- a/data/890/436/499/890436499.geojson
+++ b/data/890/436/499/890436499.geojson
@@ -43,6 +43,9 @@
     "name:bul_x_preferred":[
         "\u0410\u0441\u0438\u043b\u0430\u0445"
     ],
+    "name:bul_x_variant":[
+        "\u0410\u0441\u0438\u043b\u0430"
+    ],
     "name:cat_x_preferred":[
         "Asilah"
     ],
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":890436499,
-    "wof:lastmodified":1669163959,
+    "wof:lastmodified":1690939026,
     "wof:name":"Assilah",
     "wof:parent_id":1108784783,
     "wof:placetype":"localadmin",

--- a/data/890/436/507/890436507.geojson
+++ b/data/890/436/507/890436507.geojson
@@ -25,6 +25,9 @@
     "name:arz_x_preferred":[
         "\u0645\u0631\u0643\u0632 \u0633\u0643\u0648\u0631\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Tabounte"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0628\u0646\u062a"
     ],
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":890436507,
-    "wof:lastmodified":1669163961,
+    "wof:lastmodified":1690939027,
     "wof:name":"Tabounte",
     "wof:parent_id":1108784843,
     "wof:placetype":"localadmin",

--- a/data/890/436/513/890436513.geojson
+++ b/data/890/436/513/890436513.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Chbanate"
     ],
+    "name:ceb_x_preferred":[
+        "Chbanate"
+    ],
     "name:eng_x_preferred":[
         "Chbanate"
     ],
@@ -42,6 +45,9 @@
         "Chbanate (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Chbanate"
+    ],
+    "name:swe_x_preferred":[
         "Chbanate"
     ],
     "name:urd_x_preferred":[
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890436513,
-    "wof:lastmodified":1669163964,
+    "wof:lastmodified":1690939030,
     "wof:name":"Chbanate",
     "wof:parent_id":890429091,
     "wof:placetype":"localadmin",

--- a/data/890/436/791/890436791.geojson
+++ b/data/890/436/791/890436791.geojson
@@ -94,6 +94,9 @@
     "name:swe_x_preferred":[
         "Taza"
     ],
+    "name:tur_x_preferred":[
+        "Taza"
+    ],
     "name:und_x_variant":[
         "\u0627\u0642\u0644\u064a\u0645 \u062a\u0627\u0632\u0629",
         "Province du Tadla"
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":890436791,
-    "wof:lastmodified":1669163980,
+    "wof:lastmodified":1690939025,
     "wof:name":"Taza",
     "wof:parent_id":1796661365,
     "wof:placetype":"county",

--- a/data/890/437/785/890437785.geojson
+++ b/data/890/437/785/890437785.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "M'Haya"
     ],
+    "name:ceb_x_preferred":[
+        "M Haya"
+    ],
     "name:eng_x_preferred":[
         "M'Haya"
     ],
@@ -50,6 +53,9 @@
     ],
     "name:spa_x_preferred":[
         "M'haya"
+    ],
+    "name:swe_x_preferred":[
+        "M'Haya"
     ],
     "qs:name":"M Haya",
     "qs:photos_9r":0,
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":890437785,
-    "wof:lastmodified":1669163983,
+    "wof:lastmodified":1690939013,
     "wof:name":"M Haya",
     "wof:parent_id":1108784837,
     "wof:placetype":"localadmin",

--- a/data/890/437/877/890437877.geojson
+++ b/data/890/437/877/890437877.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u062a\u0627\u0632\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Taza"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0627\u0632\u0647"
     ],
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":890437877,
-    "wof:lastmodified":1669163989,
+    "wof:lastmodified":1690939014,
     "wof:name":"Taza",
     "wof:parent_id":890436791,
     "wof:placetype":"localadmin",

--- a/data/890/437/879/890437879.geojson
+++ b/data/890/437/879/890437879.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Arbaoua"
     ],
+    "name:ceb_x_preferred":[
+        "Arbaoua"
+    ],
     "name:deu_x_preferred":[
         "Arbaoua"
     ],
@@ -48,6 +51,9 @@
         "Arbaoua"
     ],
     "name:nld_x_preferred":[
+        "Arbaoua"
+    ],
+    "name:swe_x_preferred":[
         "Arbaoua"
     ],
     "qs:name":"Arbaoua",
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":890437879,
-    "wof:lastmodified":1669163990,
+    "wof:lastmodified":1690939014,
     "wof:name":"Arbaoua",
     "wof:parent_id":890427533,
     "wof:placetype":"localadmin",

--- a/data/890/437/999/890437999.geojson
+++ b/data/890/437/999/890437999.geojson
@@ -57,6 +57,9 @@
     "name:cat_x_preferred":[
         "Prefectura de Rabat"
     ],
+    "name:ceb_x_preferred":[
+        "Rabat"
+    ],
     "name:deu_x_preferred":[
         "Rabat"
     ],
@@ -99,6 +102,12 @@
     ],
     "name:spa_x_preferred":[
         "Prefectura de Rabat"
+    ],
+    "name:swe_x_preferred":[
+        "Rabat"
+    ],
+    "name:tur_x_preferred":[
+        "Rabat"
     ],
     "name:ukr_x_preferred":[
         "\u0420\u0430\u0431\u0430\u0442"
@@ -163,7 +172,7 @@
         }
     ],
     "wof:id":890437999,
-    "wof:lastmodified":1669163994,
+    "wof:lastmodified":1690939012,
     "wof:name":"Rabat",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/890/438/007/890438007.geojson
+++ b/data/890/438/007/890438007.geojson
@@ -56,6 +56,9 @@
     "name:swe_x_preferred":[
         "Ait Mazigh"
     ],
+    "name:uzb_x_preferred":[
+        "Ait Mazigh"
+    ],
     "qs:name":"Ait Mazigh",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890438007,
-    "wof:lastmodified":1669163996,
+    "wof:lastmodified":1690939031,
     "wof:name":"Ait Mazigh",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/438/009/890438009.geojson
+++ b/data/890/438/009/890438009.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u062c\u0631\u0627\u062f\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Yerada"
+    ],
     "name:azb_x_preferred":[
         "\u062c\u0631\u0627\u062f\u0647"
     ],
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":890438009,
-    "wof:lastmodified":1669163997,
+    "wof:lastmodified":1690939031,
     "wof:name":"Jerada",
     "wof:parent_id":1108784775,
     "wof:placetype":"localadmin",

--- a/data/890/438/011/890438011.geojson
+++ b/data/890/438/011/890438011.geojson
@@ -28,6 +28,9 @@
     "name:arz_x_preferred":[
         "\u062a\u0648\u064a\u0633\u064a\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Touissit"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0648\u06cc\u0633\u06cc\u062a"
     ],
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890438011,
-    "wof:lastmodified":1669163998,
+    "wof:lastmodified":1690939032,
     "wof:name":"Touissit",
     "wof:parent_id":1108784775,
     "wof:placetype":"localadmin",

--- a/data/890/438/165/890438165.geojson
+++ b/data/890/438/165/890438165.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Chouafaa"
     ],
+    "name:ceb_x_preferred":[
+        "Chouafaa"
+    ],
     "name:eng_x_preferred":[
         "Chouafaa"
     ],
@@ -42,6 +45,9 @@
         "Chouafaa (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Chouafaa"
+    ],
+    "name:swe_x_preferred":[
         "Chouafaa"
     ],
     "qs:name":"Chouafaa",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890438165,
-    "wof:lastmodified":1669163999,
+    "wof:lastmodified":1690939032,
     "wof:name":"Chouafaa",
     "wof:parent_id":890427533,
     "wof:placetype":"localadmin",

--- a/data/890/438/281/890438281.geojson
+++ b/data/890/438/281/890438281.geojson
@@ -54,6 +54,9 @@
     "name:ita_x_preferred":[
         "M'rirt"
     ],
+    "name:kab_x_preferred":[
+        "Mrirt"
+    ],
     "name:nld_x_preferred":[
         "M'Rirt"
     ],
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":890438281,
-    "wof:lastmodified":1669164001,
+    "wof:lastmodified":1690939031,
     "wof:name":"M'Rirt",
     "wof:parent_id":1108784791,
     "wof:placetype":"localadmin",

--- a/data/890/438/291/890438291.geojson
+++ b/data/890/438/291/890438291.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Ain Legdah"
     ],
+    "name:ceb_x_preferred":[
+        "Ain Legdah"
+    ],
     "name:eng_x_preferred":[
         "Ain Legdah"
     ],
@@ -42,6 +45,9 @@
         "Ain Legdah (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Ain Legdah"
+    ],
+    "name:swe_x_preferred":[
         "Ain Legdah"
     ],
     "qs:name":"Ain Legdah",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890438291,
-    "wof:lastmodified":1669164004,
+    "wof:lastmodified":1690939033,
     "wof:name":"Ain Legdah",
     "wof:parent_id":890418103,
     "wof:placetype":"localadmin",

--- a/data/890/440/509/890440509.geojson
+++ b/data/890/440/509/890440509.geojson
@@ -43,6 +43,9 @@
     "name:ceb_x_preferred":[
         "Al Hoce\u00efma"
     ],
+    "name:ces_x_preferred":[
+        "Al-Husajma"
+    ],
     "name:cym_x_preferred":[
         "Al Hoceima"
     ],
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":890440509,
-    "wof:lastmodified":1669164014,
+    "wof:lastmodified":1690938957,
     "wof:name":"Al Hoceima",
     "wof:parent_id":890429097,
     "wof:placetype":"localadmin",

--- a/data/890/440/511/890440511.geojson
+++ b/data/890/440/511/890440511.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u062c\u062f\u064a\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Ajdir"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u062c\u062f\u06cc\u0631"
     ],
@@ -104,6 +107,9 @@
     "name:tat_x_preferred":[
         "\u04d8\u0497\u0434\u0438\u0440"
     ],
+    "name:tur_x_preferred":[
+        "Ajdir"
+    ],
     "name:zho_x_preferred":[
         "\u963f\u6770\u8fea\u5c14"
     ],
@@ -141,7 +147,7 @@
         }
     ],
     "wof:id":890440511,
-    "wof:lastmodified":1669164015,
+    "wof:lastmodified":1690938953,
     "wof:name":"Ajdir",
     "wof:parent_id":890436791,
     "wof:placetype":"localadmin",

--- a/data/890/440/525/890440525.geojson
+++ b/data/890/440/525/890440525.geojson
@@ -56,6 +56,9 @@
     "name:swe_x_preferred":[
         "Ait Blal"
     ],
+    "name:uzb_x_preferred":[
+        "Ait Blal"
+    ],
     "qs:name":"Ait Blal",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890440525,
-    "wof:lastmodified":1669164020,
+    "wof:lastmodified":1690938966,
     "wof:name":"Ait Blal",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/440/527/890440527.geojson
+++ b/data/890/440/527/890440527.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0628\u0649 \u0627\u0644\u062c\u0639\u062f"
     ],
+    "name:ast_x_preferred":[
+        "Boujad"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0628\u0648\u0627\u0644\u062c\u0639\u062f"
     ],
@@ -87,8 +90,14 @@
     "name:swe_x_preferred":[
         "Boujad"
     ],
+    "name:swe_x_variant":[
+        "Bejaad"
+    ],
     "name:tzm_x_preferred":[
         "\u2d31\u2d4a\u2d30\u2d44\u2d37"
+    ],
+    "name:uzb_x_preferred":[
+        "Boujad"
     ],
     "name:zho_x_preferred":[
         "\u5e03\u8d3e\u5fb7"
@@ -127,7 +136,7 @@
         }
     ],
     "wof:id":890440527,
-    "wof:lastmodified":1669164021,
+    "wof:lastmodified":1690938951,
     "wof:name":"Bejaad",
     "wof:parent_id":890422519,
     "wof:placetype":"localadmin",

--- a/data/890/440/547/890440547.geojson
+++ b/data/890/440/547/890440547.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Ait Yadine"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Yadine"
+    ],
     "name:eng_x_preferred":[
         "Ait Yadine"
     ],
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890440547,
-    "wof:lastmodified":1669164028,
+    "wof:lastmodified":1690938964,
     "wof:name":"Ait Yadine",
     "wof:parent_id":890453897,
     "wof:placetype":"localadmin",

--- a/data/890/440/555/890440555.geojson
+++ b/data/890/440/555/890440555.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Tizi N'Ghachou"
     ],
+    "name:ceb_x_preferred":[
+        "Tizi N Ghachou"
+    ],
     "name:eng_x_preferred":[
         "Tizi N'Ghachou"
     ],
@@ -45,6 +48,9 @@
         "Tizi N'Ghachou"
     ],
     "name:nld_x_preferred":[
+        "Tizi N'Ghachou"
+    ],
+    "name:swe_x_preferred":[
         "Tizi N'Ghachou"
     ],
     "qs:name":"Tizi N Ghachou",
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890440555,
-    "wof:lastmodified":1669164030,
+    "wof:lastmodified":1690938955,
     "wof:name":"Tizi N Ghachou",
     "wof:parent_id":1108784795,
     "wof:placetype":"localadmin",

--- a/data/890/440/561/890440561.geojson
+++ b/data/890/440/561/890440561.geojson
@@ -77,6 +77,9 @@
     "name:heb_x_preferred":[
         "\u05d0\u05d3\u05e8"
     ],
+    "name:hun_x_preferred":[
+        "\u00e1d\u00e1r"
+    ],
     "name:ina_x_preferred":[
         "Adar"
     ],
@@ -103,6 +106,9 @@
     ],
     "name:nld_x_preferred":[
         "Adar"
+    ],
+    "name:nld_x_variant":[
+        "adar"
     ],
     "name:nno_x_preferred":[
         "Ad\u00e1r"
@@ -139,6 +145,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0434\u0430\u0440"
+    ],
+    "name:uzb_x_preferred":[
+        "Adar"
     ],
     "name:yid_x_preferred":[
         "\u05d0\u05d3\u05e8"
@@ -178,7 +187,7 @@
         }
     ],
     "wof:id":890440561,
-    "wof:lastmodified":1669164032,
+    "wof:lastmodified":1690938944,
     "wof:name":"Adar",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/440/577/890440577.geojson
+++ b/data/890/440/577/890440577.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Tighmi"
     ],
+    "name:ceb_x_preferred":[
+        "Tighmi"
+    ],
     "name:eng_x_preferred":[
         "Tighmi"
     ],
@@ -42,6 +45,9 @@
         "Tighmi (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Tighmi"
+    ],
+    "name:swe_x_preferred":[
         "Tighmi"
     ],
     "qs:name":"Tighmi",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890440577,
-    "wof:lastmodified":1669164037,
+    "wof:lastmodified":1690938967,
     "wof:name":"Tighmi",
     "wof:parent_id":890428801,
     "wof:placetype":"localadmin",

--- a/data/890/440/599/890440599.geojson
+++ b/data/890/440/599/890440599.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Talat N'Yaaqoub"
     ],
+    "name:ceb_x_preferred":[
+        "Talat N Yaaqoub"
+    ],
     "name:deu_x_preferred":[
         "Talat N\u2019Yaaqoub"
     ],
@@ -52,6 +55,9 @@
         "Talat N'Yaaqoub"
     ],
     "name:ita_x_preferred":[
+        "Talat N'Yaaqoub"
+    ],
+    "name:swe_x_preferred":[
         "Talat N'Yaaqoub"
     ],
     "name:urd_x_preferred":[
@@ -89,7 +95,7 @@
         }
     ],
     "wof:id":890440599,
-    "wof:lastmodified":1669164042,
+    "wof:lastmodified":1690938956,
     "wof:name":"Talat N Yaaqoub",
     "wof:parent_id":1108784801,
     "wof:placetype":"localadmin",

--- a/data/890/440/607/890440607.geojson
+++ b/data/890/440/607/890440607.geojson
@@ -32,6 +32,9 @@
     "name:cat_x_preferred":[
         "M'Zouda"
     ],
+    "name:ceb_x_preferred":[
+        "M Zouda"
+    ],
     "name:deu_x_preferred":[
         "Mzouda"
     ],
@@ -66,6 +69,9 @@
     ],
     "name:swe_x_preferred":[
         "Mzouda"
+    ],
+    "name:swe_x_variant":[
+        "M'Zouda"
     ],
     "name:urd_x_preferred":[
         "\u0645'\u0632\u0648\u062f\u0627"
@@ -102,7 +108,7 @@
         }
     ],
     "wof:id":890440607,
-    "wof:lastmodified":1669164044,
+    "wof:lastmodified":1690938964,
     "wof:name":"M Zouda",
     "wof:parent_id":890440847,
     "wof:placetype":"localadmin",

--- a/data/890/440/629/890440629.geojson
+++ b/data/890/440/629/890440629.geojson
@@ -146,6 +146,9 @@
     "name:mar_x_preferred":[
         "\u090f\u0938\u093e\u0909\u0907\u0930\u093e"
     ],
+    "name:mlt_x_preferred":[
+        "Essaouira"
+    ],
     "name:msa_x_preferred":[
         "Essaouira"
     ],
@@ -265,7 +268,7 @@
         }
     ],
     "wof:id":890440629,
-    "wof:lastmodified":1669164045,
+    "wof:lastmodified":1690938947,
     "wof:name":"Essaouira",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/440/649/890440649.geojson
+++ b/data/890/440/649/890440649.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Ait Abbas"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Abbas"
+    ],
     "name:eng_x_preferred":[
         "Ait Abbas"
     ],
@@ -45,6 +48,9 @@
         "Ait Abbas (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Ait Abbas"
+    ],
+    "name:swe_x_preferred":[
         "Ait Abbas"
     ],
     "qs:name":"Ait Abbas",
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890440649,
-    "wof:lastmodified":1669164050,
+    "wof:lastmodified":1690938959,
     "wof:name":"Ait Abbas",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/440/651/890440651.geojson
+++ b/data/890/440/651/890440651.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Ait Bou Oulli"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Bou Oulli"
+    ],
     "name:eng_x_preferred":[
         "Ait Bou Oulli"
     ],
@@ -52,6 +55,12 @@
     ],
     "name:rif_x_preferred":[
         "ait"
+    ],
+    "name:swe_x_preferred":[
+        "Ait Bou Oulli"
+    ],
+    "name:uzb_x_preferred":[
+        "Ait Bou Oulli"
     ],
     "qs:name":"Ait Bou Oulli",
     "qs:photos_9r":0,
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":890440651,
-    "wof:lastmodified":1669164051,
+    "wof:lastmodified":1690938948,
     "wof:name":"Ait Bou Oulli",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/440/655/890440655.geojson
+++ b/data/890/440/655/890440655.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Ait Tamlil"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Tamlil"
+    ],
     "name:eng_x_preferred":[
         "Ait Tamlil"
     ],
@@ -45,6 +48,12 @@
         "Ait Tamlil (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Ait Tamlil"
+    ],
+    "name:swe_x_preferred":[
+        "A\u00eft Tamlil"
+    ],
+    "name:uzb_x_preferred":[
         "Ait Tamlil"
     ],
     "qs:name":"Ait Tamlil",
@@ -79,7 +88,7 @@
         }
     ],
     "wof:id":890440655,
-    "wof:lastmodified":1669164053,
+    "wof:lastmodified":1690938961,
     "wof:name":"Ait Tamlil",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/440/667/890440667.geojson
+++ b/data/890/440/667/890440667.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Hiadna"
     ],
+    "name:ceb_x_preferred":[
+        "Hiadna"
+    ],
     "name:eng_x_preferred":[
         "Hiadna"
     ],
@@ -48,6 +51,9 @@
         "Hiadna (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Hiadna"
+    ],
+    "name:swe_x_preferred":[
         "Hiadna"
     ],
     "qs:name":"Hiadna",
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":890440667,
-    "wof:lastmodified":1669164055,
+    "wof:lastmodified":1690938948,
     "wof:name":"Hiadna",
     "wof:parent_id":1108784785,
     "wof:placetype":"localadmin",

--- a/data/890/440/681/890440681.geojson
+++ b/data/890/440/681/890440681.geojson
@@ -76,6 +76,9 @@
     "name:eng_x_preferred":[
         "El Jadida"
     ],
+    "name:eng_x_variant":[
+        "Sinigal"
+    ],
     "name:epo_x_preferred":[
         "El Jadida"
     ],
@@ -265,7 +268,7 @@
         }
     ],
     "wof:id":890440681,
-    "wof:lastmodified":1669164057,
+    "wof:lastmodified":1690938945,
     "wof:name":"El-Jadida",
     "wof:parent_id":890445399,
     "wof:placetype":"localadmin",

--- a/data/890/440/683/890440683.geojson
+++ b/data/890/440/683/890440683.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0633\u064a\u062f\u0649 \u0628\u0646\u0648\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Sidi Bennour"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0628\u0646\u0648\u0631"
     ],
@@ -58,6 +61,9 @@
     "name:eng_x_preferred":[
         "Sidi Bennour"
     ],
+    "name:eng_x_variant":[
+        "el jadida"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0628\u0646\u0648\u0631"
     ],
@@ -82,6 +88,12 @@
     ],
     "name:jpn_x_variant":[
         "\u30b7\u30c7\u30a3 \u30d9\u30ce\u30fc\u30eb"
+    ],
+    "name:mlt_x_preferred":[
+        "Sidi Bennour"
+    ],
+    "name:msa_x_preferred":[
+        "Sidi Bennour"
     ],
     "name:nan_x_preferred":[
         "Sidi Bennour"
@@ -154,7 +166,7 @@
         }
     ],
     "wof:id":890440683,
-    "wof:lastmodified":1669164058,
+    "wof:lastmodified":1690938961,
     "wof:name":"Sidi Bennour",
     "wof:parent_id":1108784819,
     "wof:placetype":"localadmin",

--- a/data/890/440/705/890440705.geojson
+++ b/data/890/440/705/890440705.geojson
@@ -57,6 +57,9 @@
     "name:swe_x_preferred":[
         "Foum Jemaa"
     ],
+    "name:uzb_x_preferred":[
+        "Foum Jamaa"
+    ],
     "qs:name":"Foum Jemaa",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":890440705,
-    "wof:lastmodified":1669164065,
+    "wof:lastmodified":1690938954,
     "wof:name":"Foum Jemaa",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/440/709/890440709.geojson
+++ b/data/890/440/709/890440709.geojson
@@ -50,6 +50,9 @@
     "name:swe_x_preferred":[
         "Tisqi"
     ],
+    "name:uzb_x_preferred":[
+        "Tisqi"
+    ],
     "qs:name":"Tisqi",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890440709,
-    "wof:lastmodified":1669164066,
+    "wof:lastmodified":1690938944,
     "wof:name":"Tisqi",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/440/711/890440711.geojson
+++ b/data/890/440/711/890440711.geojson
@@ -56,6 +56,9 @@
     "name:swe_x_preferred":[
         "Ait Majden"
     ],
+    "name:uzb_x_preferred":[
+        "Ait Majden"
+    ],
     "qs:name":"Ait Majden",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890440711,
-    "wof:lastmodified":1669164066,
+    "wof:lastmodified":1690938967,
     "wof:name":"Ait Majden",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/440/719/890440719.geojson
+++ b/data/890/440/719/890440719.geojson
@@ -23,7 +23,11 @@
         "\u0623\u064a\u062a \u0645\u0632\u064a\u063a"
     ],
     "name:ara_x_variant":[
-        "\u0622\u064a\u062a \u0648\u0627\u0648\u0631\u062f\u0627"
+        "\u0622\u064a\u062a \u0648\u0627\u0648\u0631\u062f\u0627",
+        "\u0622\u064a\u062a \u0648\u0639\u0631\u0636\u0649"
+    ],
+    "name:ary_x_preferred":[
+        "\u0622\u064a\u062a \u0648\u0639\u0631\u0636\u0649"
     ],
     "name:azb_x_preferred":[
         "\u0622\u06cc\u062a \u0627\u0648\u0627\u0631\u062f\u0627"
@@ -50,7 +54,16 @@
     "name:ita_x_preferred":[
         "Ait Ouaarda"
     ],
+    "name:por_x_preferred":[
+        "Ait Ouaarda"
+    ],
+    "name:spa_x_preferred":[
+        "Ait Ouaarda"
+    ],
     "name:swe_x_preferred":[
+        "Ait Ouaarda"
+    ],
+    "name:uzb_x_preferred":[
         "Ait Ouaarda"
     ],
     "qs:name":"Ait Ouaarda",
@@ -85,7 +98,7 @@
         }
     ],
     "wof:id":890440719,
-    "wof:lastmodified":1669156526,
+    "wof:lastmodified":1690938965,
     "wof:name":"Ait Ouaarda",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/440/723/890440723.geojson
+++ b/data/890/440/723/890440723.geojson
@@ -58,6 +58,9 @@
     "name:swe_x_preferred":[
         "Bin El Ouidane"
     ],
+    "name:uzb_x_preferred":[
+        "Bin El Ouidane"
+    ],
     "qs:name":"Bin El Ouidane",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":890440723,
-    "wof:lastmodified":1669164070,
+    "wof:lastmodified":1690938952,
     "wof:name":"Bin El Ouidane",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/440/765/890440765.geojson
+++ b/data/890/440/765/890440765.geojson
@@ -53,6 +53,9 @@
     "name:swe_x_preferred":[
         "Oulad M'Barek"
     ],
+    "name:swe_x_variant":[
+        "Ouled M'Barek"
+    ],
     "qs:name":"Oulad M'Barek",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890440765,
-    "wof:lastmodified":1669164081,
+    "wof:lastmodified":1690938944,
     "wof:name":"Oulad M'Barek",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/440/781/890440781.geojson
+++ b/data/890/440/781/890440781.geojson
@@ -62,6 +62,9 @@
     "name:swe_x_preferred":[
         "Sidi Yahia el Gharb"
     ],
+    "name:swe_x_variant":[
+        "Sidi Yahya El Gharb"
+    ],
     "qs:name":"Sidi Yahya El Gharb",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":890440781,
-    "wof:lastmodified":1669164082,
+    "wof:lastmodified":1690938964,
     "wof:name":"Sidi Yahya El Gharb",
     "wof:parent_id":890427533,
     "wof:placetype":"localadmin",

--- a/data/890/440/789/890440789.geojson
+++ b/data/890/440/789/890440789.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Oulad Slama"
     ],
+    "name:ceb_x_preferred":[
+        "Oulad Slama"
+    ],
     "name:eng_x_preferred":[
         "Oulad Slama"
     ],
@@ -45,6 +48,9 @@
         "Oulad Slama"
     ],
     "name:nld_x_preferred":[
+        "Oulad Slama"
+    ],
+    "name:swe_x_preferred":[
         "Oulad Slama"
     ],
     "qs:name":"Oulad Slama",
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890440789,
-    "wof:lastmodified":1669164084,
+    "wof:lastmodified":1690938966,
     "wof:name":"Oulad Slama",
     "wof:parent_id":890427533,
     "wof:placetype":"localadmin",

--- a/data/890/440/825/890440825.geojson
+++ b/data/890/440/825/890440825.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Asjen"
     ],
+    "name:ceb_x_preferred":[
+        "Asjen"
+    ],
     "name:eng_x_preferred":[
         "Asjen"
     ],
@@ -42,6 +45,9 @@
         "Asjen (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Asjen"
+    ],
+    "name:swe_x_preferred":[
         "Asjen"
     ],
     "name:urd_x_preferred":[
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890440825,
-    "wof:lastmodified":1669164093,
+    "wof:lastmodified":1690938960,
     "wof:name":"Asjen",
     "wof:parent_id":1108784797,
     "wof:placetype":"localadmin",

--- a/data/890/440/827/890440827.geojson
+++ b/data/890/440/827/890440827.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Brikcha"
     ],
+    "name:ceb_x_preferred":[
+        "Brikcha"
+    ],
     "name:eng_x_preferred":[
         "Brikcha"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:pol_x_preferred":[
         "Bariksza"
+    ],
+    "name:swe_x_preferred":[
+        "Brikcha"
     ],
     "name:urd_x_preferred":[
         "\u0628\u0631\u06cc\u06a9\u0634\u06c1"
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890440827,
-    "wof:lastmodified":1669164094,
+    "wof:lastmodified":1690938945,
     "wof:name":"Brikcha",
     "wof:parent_id":1108784797,
     "wof:placetype":"localadmin",

--- a/data/890/440/829/890440829.geojson
+++ b/data/890/440/829/890440829.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Souk L'Qolla"
     ],
+    "name:ceb_x_preferred":[
+        "Souk L Qolla"
+    ],
     "name:eng_x_preferred":[
         "Souk L'Qolla"
     ],
@@ -42,6 +45,9 @@
         "Souk L Qolla (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Souk L'Qolla"
+    ],
+    "name:swe_x_preferred":[
         "Souk L'Qolla"
     ],
     "name:urd_x_preferred":[
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890440829,
-    "wof:lastmodified":1669164095,
+    "wof:lastmodified":1690938946,
     "wof:name":"Souk L Qolla",
     "wof:parent_id":890422513,
     "wof:placetype":"localadmin",

--- a/data/890/440/831/890440831.geojson
+++ b/data/890/440/831/890440831.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0632\u063a\u0646\u063a\u0627\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Zeghanghane"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0632\u063a\u0646\u063a\u0627\u0646"
     ],
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":890440831,
-    "wof:lastmodified":1669164096,
+    "wof:lastmodified":1690938962,
     "wof:name":"Zeghanghane",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/440/833/890440833.geojson
+++ b/data/890/440/833/890440833.geojson
@@ -47,6 +47,12 @@
     "name:ita_x_preferred":[
         "Bni Sidel Louta"
     ],
+    "name:por_x_preferred":[
+        "Bni Sidel Louta"
+    ],
+    "name:spa_x_preferred":[
+        "Bni Sidel Louta"
+    ],
     "name:swe_x_preferred":[
         "Bni Sidel Louta"
     ],
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":890440833,
-    "wof:lastmodified":1669164097,
+    "wof:lastmodified":1690938949,
     "wof:name":"Bni Sidel Louta",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/440/847/890440847.geojson
+++ b/data/890/440/847/890440847.geojson
@@ -97,6 +97,9 @@
     "name:swe_x_preferred":[
         "Chichaoua"
     ],
+    "name:tur_x_preferred":[
+        "\u015ei\u015fava"
+    ],
     "name:urd_x_preferred":[
         "\u0634\u06cc\u0634\u0627\u0648\u06c1 \u0635\u0648\u0628\u06c1"
     ],
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":890440847,
-    "wof:lastmodified":1669164121,
+    "wof:lastmodified":1690938960,
     "wof:name":"Chichaoua",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/890/440/849/890440849.geojson
+++ b/data/890/440/849/890440849.geojson
@@ -92,6 +92,9 @@
     "name:swe_x_preferred":[
         "Sefrou"
     ],
+    "name:tur_x_preferred":[
+        "Safru"
+    ],
     "name:zho_x_preferred":[
         "\u585e\u592b\u52de\u7701"
     ],
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":890440849,
-    "wof:lastmodified":1669164132,
+    "wof:lastmodified":1690938959,
     "wof:name":"Sefrou",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/440/867/890440867.geojson
+++ b/data/890/440/867/890440867.geojson
@@ -23,7 +23,8 @@
         "\u0644\u0643\u0641\u064a\u0641\u0627\u062a"
     ],
     "name:ara_x_variant":[
-        "\u0627\u0644\u062e\u0646\u0627\u0646\u064a\u0641"
+        "\u0627\u0644\u062e\u0646\u0627\u0646\u064a\u0641",
+        "\u0627\u0644\u062e\u0646\u0627\u0641\u064a\u0641"
     ],
     "name:ary_x_preferred":[
         "\u0644\u062e\u0646\u0627\u0641\u064a\u0641"
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":890440867,
-    "wof:lastmodified":1669164134,
+    "wof:lastmodified":1690938949,
     "wof:name":"Lakhnafif",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/440/881/890440881.geojson
+++ b/data/890/440/881/890440881.geojson
@@ -32,6 +32,9 @@
     "name:cat_x_preferred":[
         "Tazarine"
     ],
+    "name:ceb_x_preferred":[
+        "Tazarine"
+    ],
     "name:eng_x_preferred":[
         "Tazarine"
     ],
@@ -46,6 +49,9 @@
         "Tazarine"
     ],
     "name:spa_x_preferred":[
+        "Tazarine"
+    ],
+    "name:swe_x_preferred":[
         "Tazarine"
     ],
     "qs:name":"Tazarine",
@@ -89,7 +95,7 @@
         }
     ],
     "wof:id":890440881,
-    "wof:lastmodified":1669164138,
+    "wof:lastmodified":1690938947,
     "wof:name":"Tazarine",
     "wof:parent_id":890424149,
     "wof:placetype":"localadmin",

--- a/data/890/440/885/890440885.geojson
+++ b/data/890/440/885/890440885.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_variant":[
         "\u062a\u0627\u0645\u062f\u0631\u0648\u0633\u062a"
     ],
+    "name:ary_x_preferred":[
+        "\u062a\u0627\u0645\u062f\u0631\u0648\u0633\u062a"
+    ],
     "name:bul_x_preferred":[
         "\u0422\u0430\u043c\u0430\u0434\u0440\u043e\u0443\u0441\u0442"
     ],
@@ -42,6 +45,12 @@
         "Tamadroust (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Tamadroust"
+    ],
+    "name:por_x_preferred":[
+        "Tamadroust"
+    ],
+    "name:spa_x_preferred":[
         "Tamadroust"
     ],
     "name:swe_x_preferred":[
@@ -79,7 +88,7 @@
         }
     ],
     "wof:id":890440885,
-    "wof:lastmodified":1669156899,
+    "wof:lastmodified":1690938960,
     "wof:name":"Tamadroust",
     "wof:parent_id":1108784833,
     "wof:placetype":"localadmin",

--- a/data/890/440/903/890440903.geojson
+++ b/data/890/440/903/890440903.geojson
@@ -25,20 +25,44 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u0648\u0644\u064a\u062f\u064a\u0629"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u0648\u0627\u0644\u064a\u062f\u064a\u0629"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0648\u0644\u06cc\u062f\u06cc\u0647"
     ],
     "name:bul_x_preferred":[
         "\u041b\u043e\u0443\u0430\u043b\u0438\u0434\u0438\u0430"
     ],
+    "name:bul_x_variant":[
+        "\u041e\u0443\u0430\u043b\u0438\u0434\u0438\u0430"
+    ],
     "name:cat_x_preferred":[
         "Loualidia"
+    ],
+    "name:cat_x_variant":[
+        "Oualidia"
     ],
     "name:ceb_x_preferred":[
         "Loualidia"
     ],
+    "name:ceb_x_variant":[
+        "Oualidia"
+    ],
+    "name:ces_x_preferred":[
+        "Oualidia"
+    ],
+    "name:cym_x_preferred":[
+        "Oualidia"
+    ],
+    "name:deu_x_preferred":[
+        "Oualidia"
+    ],
     "name:eng_x_preferred":[
         "Loualidia"
+    ],
+    "name:eng_x_variant":[
+        "Oualidia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0648\u0644\u06cc\u062f\u06cc\u0647"
@@ -48,13 +72,44 @@
     ],
     "name:fra_x_variant":[
         "Loualidia (CR)",
-        "Loualidia (Commune Rurale)"
+        "Loualidia (Commune Rurale)",
+        "Oualidia"
+    ],
+    "name:hrv_x_preferred":[
+        "Oualidia"
     ],
     "name:ita_x_preferred":[
         "Loualidia"
     ],
+    "name:ita_x_variant":[
+        "Oualidia"
+    ],
+    "name:nld_x_preferred":[
+        "Oualidia"
+    ],
+    "name:pol_x_preferred":[
+        "Oualidia"
+    ],
+    "name:por_x_preferred":[
+        "Oualidia"
+    ],
+    "name:rus_x_preferred":[
+        "\u0423\u0430\u043b\u0438\u0434\u0438\u044f"
+    ],
+    "name:slk_x_preferred":[
+        "Oualidia"
+    ],
+    "name:spa_x_preferred":[
+        "Oualidia"
+    ],
     "name:swe_x_preferred":[
         "Loualidia"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0423\u0430\u043b\u0456\u0434\u0456\u044f"
+    ],
+    "name:wln_x_preferred":[
+        "El Walidiya"
     ],
     "qs:name":"Loualidia",
     "qs:photos_9r":0,
@@ -88,7 +143,7 @@
         }
     ],
     "wof:id":890440903,
-    "wof:lastmodified":1669156910,
+    "wof:lastmodified":1690938956,
     "wof:name":"Loualidia",
     "wof:parent_id":1108784819,
     "wof:placetype":"localadmin",

--- a/data/890/440/913/890440913.geojson
+++ b/data/890/440/913/890440913.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Oulad Ayad"
     ],
+    "name:ceb_x_preferred":[
+        "Oulad Ayad"
+    ],
     "name:deu_x_preferred":[
         "Oulad Ayad"
     ],
@@ -55,6 +58,9 @@
     ],
     "name:nld_x_preferred":[
         "Oulad Ayad"
+    ],
+    "name:swe_x_preferred":[
+        "Ouled Ayad"
     ],
     "qs:name":"Oulad Ayad",
     "qs:photos_9r":0,
@@ -88,7 +94,7 @@
         }
     ],
     "wof:id":890440913,
-    "wof:lastmodified":1669164141,
+    "wof:lastmodified":1690938954,
     "wof:name":"Oulad Ayad",
     "wof:parent_id":1108784787,
     "wof:placetype":"localadmin",

--- a/data/890/440/915/890440915.geojson
+++ b/data/890/440/915/890440915.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0631\u0634\u064a\u062f\u064a\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Errachidia"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0634\u06cc\u062f\u06cc\u0647"
     ],
@@ -80,6 +83,9 @@
     "name:lit_x_preferred":[
         "Er Ra\u0161idija"
     ],
+    "name:msa_x_preferred":[
+        "Errachidia"
+    ],
     "name:nld_x_preferred":[
         "Errachidia"
     ],
@@ -110,11 +116,17 @@
     "name:swe_x_preferred":[
         "Errachidia"
     ],
+    "name:tur_x_preferred":[
+        "Er-Ra\u015fidiye"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u0440-\u0420\u0430\u0448\u0438\u0434\u0456\u044f"
     ],
     "name:urd_x_preferred":[
         "\u0627\u0644\u0631\u0634\u06cc\u062f\u06cc\u06c1"
+    ],
+    "name:uzb_x_preferred":[
+        "Erraxidiya"
     ],
     "name:xmf_x_preferred":[
         "\u10d4\u10e0-\u10e0\u10d0\u10e8\u10d8\u10d3\u10d8\u10d0"
@@ -156,7 +168,7 @@
         }
     ],
     "wof:id":890440915,
-    "wof:lastmodified":1669164142,
+    "wof:lastmodified":1690938950,
     "wof:name":"Errachidia",
     "wof:parent_id":1108784773,
     "wof:placetype":"localadmin",

--- a/data/890/440/923/890440923.geojson
+++ b/data/890/440/923/890440923.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0631\u0645\u0627\u0646\u0649"
     ],
+    "name:ast_x_preferred":[
+        "Rommani"
+    ],
     "name:bul_x_preferred":[
         "\u0420\u043e\u043c\u0430\u043d\u0438"
     ],
@@ -61,6 +64,9 @@
     ],
     "name:shi_x_preferred":[
         "Rummani"
+    ],
+    "name:swe_x_preferred":[
+        "Rommani"
     ],
     "qs:name":"Rommani",
     "qs:photos_9r":0,
@@ -96,7 +102,7 @@
         }
     ],
     "wof:id":890440923,
-    "wof:lastmodified":1669164143,
+    "wof:lastmodified":1690938951,
     "wof:name":"Rommani",
     "wof:parent_id":890453897,
     "wof:placetype":"localadmin",

--- a/data/890/440/945/890440945.geojson
+++ b/data/890/440/945/890440945.geojson
@@ -37,6 +37,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u042d\u0440\u0444\u0443\u0434"
     ],
+    "name:bel_x_variant":[
+        "\u042d\u0440\u0444\u0443\u0434"
+    ],
     "name:cat_x_preferred":[
         "Erfoud"
     ],
@@ -65,6 +68,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05d0\u05e8\u05e4\u05d5\u05d3"
+    ],
+    "name:hye_x_preferred":[
+        "\u0537\u0580\u0586\u0578\u0582\u0564"
     ],
     "name:ita_x_preferred":[
         "Erfoud"
@@ -98,6 +104,9 @@
     ],
     "name:swe_x_preferred":[
         "Erfoud"
+    ],
+    "name:swe_x_variant":[
+        "Arfoud"
     ],
     "name:zho_x_preferred":[
         "\u5384\u592b"
@@ -134,7 +143,7 @@
         }
     ],
     "wof:id":890440945,
-    "wof:lastmodified":1669164151,
+    "wof:lastmodified":1690938966,
     "wof:name":"Arfoud",
     "wof:parent_id":1108784773,
     "wof:placetype":"localadmin",

--- a/data/890/440/955/890440955.geojson
+++ b/data/890/440/955/890440955.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Fritissa"
     ],
+    "name:ceb_x_preferred":[
+        "Fritissa"
+    ],
     "name:eng_x_preferred":[
         "Fritissa"
     ],
@@ -42,6 +45,9 @@
         "Fritissa (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Fritissa"
+    ],
+    "name:swe_x_preferred":[
         "Fritissa"
     ],
     "qs:name":"Fritissa",
@@ -84,7 +90,7 @@
         }
     ],
     "wof:id":890440955,
-    "wof:lastmodified":1669164154,
+    "wof:lastmodified":1690938945,
     "wof:name":"Fritissa",
     "wof:parent_id":890436419,
     "wof:placetype":"localadmin",

--- a/data/890/440/971/890440971.geojson
+++ b/data/890/440/971/890440971.geojson
@@ -54,6 +54,9 @@
     "name:nld_x_preferred":[
         "Ihddaden"
     ],
+    "name:por_x_preferred":[
+        "Ihddaden"
+    ],
     "name:spa_x_preferred":[
         "Iheddad\u00e9n"
     ],
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":890440971,
-    "wof:lastmodified":1669164156,
+    "wof:lastmodified":1690938952,
     "wof:name":"Ihaddadene",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/441/017/890441017.geojson
+++ b/data/890/441/017/890441017.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Temsamane"
     ],
+    "name:ceb_x_preferred":[
+        "Temsamane"
+    ],
     "name:deu_x_preferred":[
         "Temsamane"
     ],
@@ -67,6 +70,9 @@
     ],
     "name:spa_x_preferred":[
         "Temsaman"
+    ],
+    "name:swe_x_preferred":[
+        "Temsamane"
     ],
     "name:urd_x_preferred":[
         "\u062a\u0645\u0633\u0645\u0627\u0646"
@@ -106,7 +112,7 @@
         }
     ],
     "wof:id":890441017,
-    "wof:lastmodified":1669164157,
+    "wof:lastmodified":1690938980,
     "wof:name":"Temsamane",
     "wof:parent_id":1108784779,
     "wof:placetype":"localadmin",

--- a/data/890/441/029/890441029.geojson
+++ b/data/890/441/029/890441029.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Souk Lakhmis Dades"
     ],
+    "name:cat_x_variant":[
+        "Souk Lakhmis Dad\u00e8s"
+    ],
     "name:ceb_x_preferred":[
         "Souk Lakhmis Dades"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:eng_x_preferred":[
         "Souk Lakhmis Dades"
+    ],
+    "name:eng_x_variant":[
+        "Khemis Dades"
     ],
     "name:fas_x_preferred":[
         "\u0633\u0648\u0642 \u0627\u0644\u062e\u0645\u06cc\u0633 \u062f\u0627\u062f\u0633"
@@ -56,6 +62,12 @@
     ],
     "name:ita_x_preferred":[
         "Souk Lakhmis Dades"
+    ],
+    "name:ita_x_variant":[
+        "Souk Lakhmis Dad\u00e8s"
+    ],
+    "name:nld_x_preferred":[
+        "Khemis Dades"
     ],
     "name:swe_x_preferred":[
         "Souk Lakhmis Dades"
@@ -92,7 +104,7 @@
         }
     ],
     "wof:id":890441029,
-    "wof:lastmodified":1669164161,
+    "wof:lastmodified":1690938980,
     "wof:name":"Souk Lakhmis Dades",
     "wof:parent_id":1108784839,
     "wof:placetype":"localadmin",

--- a/data/890/441/041/890441041.geojson
+++ b/data/890/441/041/890441041.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Takate"
     ],
+    "name:ceb_x_preferred":[
+        "Takate"
+    ],
     "name:eng_x_preferred":[
         "Takate"
     ],
@@ -45,6 +48,9 @@
         "Takate (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Takate"
+    ],
+    "name:swe_x_preferred":[
         "Takate"
     ],
     "qs:name":"Takate",
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890441041,
-    "wof:lastmodified":1669164165,
+    "wof:lastmodified":1690938974,
     "wof:name":"Takate",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/441/045/890441045.geojson
+++ b/data/890/441/045/890441045.geojson
@@ -51,6 +51,9 @@
     "name:swe_x_preferred":[
         "Khemis du Sahel"
     ],
+    "name:swe_x_variant":[
+        "Khemis Sahel"
+    ],
     "qs:name":"Khemis Sahel",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":890441045,
-    "wof:lastmodified":1669164167,
+    "wof:lastmodified":1690938979,
     "wof:name":"Khemis Sahel",
     "wof:parent_id":890422513,
     "wof:placetype":"localadmin",

--- a/data/890/441/053/890441053.geojson
+++ b/data/890/441/053/890441053.geojson
@@ -53,6 +53,9 @@
     "name:ita_x_preferred":[
         "Tiztoutine"
     ],
+    "name:por_x_preferred":[
+        "Tiztoutine"
+    ],
     "name:spa_x_preferred":[
         "Tiztoutine"
     ],
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":890441053,
-    "wof:lastmodified":1669164170,
+    "wof:lastmodified":1690938975,
     "wof:name":"Tiztoutine",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/441/057/890441057.geojson
+++ b/data/890/441/057/890441057.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Tancherfi"
     ],
+    "name:ceb_x_preferred":[
+        "Tancherfi"
+    ],
     "name:eng_x_preferred":[
         "Tancherfi"
     ],
@@ -42,6 +45,9 @@
         "Tancherfi (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Tancherfi"
+    ],
+    "name:swe_x_preferred":[
         "Tancherfi"
     ],
     "qs:name":"Tancherfi",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890441057,
-    "wof:lastmodified":1669164171,
+    "wof:lastmodified":1690938982,
     "wof:name":"Tancherfi",
     "wof:parent_id":1108784813,
     "wof:placetype":"localadmin",

--- a/data/890/441/067/890441067.geojson
+++ b/data/890/441/067/890441067.geojson
@@ -50,6 +50,9 @@
     "name:nld_x_preferred":[
         "Ziaida"
     ],
+    "name:swe_x_preferred":[
+        "Ziaida"
+    ],
     "qs:name":"Ziaida",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890441067,
-    "wof:lastmodified":1669164175,
+    "wof:lastmodified":1690938983,
     "wof:name":"Ziaida",
     "wof:parent_id":890436421,
     "wof:placetype":"localadmin",

--- a/data/890/441/103/890441103.geojson
+++ b/data/890/441/103/890441103.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "M'Semrir"
     ],
+    "name:ceb_x_preferred":[
+        "M Semrir"
+    ],
     "name:deu_x_preferred":[
         "M'Semrir"
     ],
@@ -58,6 +61,9 @@
         "M'Semrir"
     ],
     "name:por_x_preferred":[
+        "M'Semrir"
+    ],
+    "name:swe_x_preferred":[
         "M'Semrir"
     ],
     "qs:name":"M Semrir",
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":890441103,
-    "wof:lastmodified":1669164184,
+    "wof:lastmodified":1690938971,
     "wof:name":"M Semrir",
     "wof:parent_id":1108784839,
     "wof:placetype":"localadmin",

--- a/data/890/441/107/890441107.geojson
+++ b/data/890/441/107/890441107.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Taghzoute N'Ait Atta"
     ],
+    "name:ceb_x_preferred":[
+        "Taghzoute N Ait Atta"
+    ],
     "name:eng_x_preferred":[
         "Taghzoute N'Ait Atta"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:ita_x_preferred":[
         "Taghzoute N'Ait Atta"
+    ],
+    "name:swe_x_preferred":[
+        "Taghzoute N'A\u00eft Atta"
     ],
     "qs:name":"Taghzoute N Ait Atta",
     "qs:photos_9r":0,
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":890441107,
-    "wof:lastmodified":1669164186,
+    "wof:lastmodified":1690938978,
     "wof:name":"Taghzoute N Ait Atta",
     "wof:parent_id":1108784839,
     "wof:placetype":"localadmin",

--- a/data/890/441/137/890441137.geojson
+++ b/data/890/441/137/890441137.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Mezraoua"
     ],
+    "name:ceb_x_preferred":[
+        "Mezraoua"
+    ],
     "name:eng_x_preferred":[
         "Mezraoua"
     ],
@@ -42,6 +45,9 @@
         "Mezraoua (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Mezraoua"
+    ],
+    "name:swe_x_preferred":[
         "Mezraoua"
     ],
     "qs:name":"Mezraoua",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890441137,
-    "wof:lastmodified":1669164190,
+    "wof:lastmodified":1690938979,
     "wof:name":"Mezraoua",
     "wof:parent_id":890418103,
     "wof:placetype":"localadmin",

--- a/data/890/441/147/890441147.geojson
+++ b/data/890/441/147/890441147.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Zinat"
     ],
+    "name:ceb_x_preferred":[
+        "Zinat"
+    ],
     "name:deu_x_preferred":[
         "Zinat"
     ],
@@ -54,6 +57,9 @@
         "Zinat"
     ],
     "name:spa_x_preferred":[
+        "Zinat"
+    ],
+    "name:swe_x_preferred":[
         "Zinat"
     ],
     "name:urd_x_preferred":[
@@ -91,7 +97,7 @@
         }
     ],
     "wof:id":890441147,
-    "wof:lastmodified":1669164194,
+    "wof:lastmodified":1690938984,
     "wof:name":"Zinat",
     "wof:parent_id":890421483,
     "wof:placetype":"localadmin",

--- a/data/890/441/161/890441161.geojson
+++ b/data/890/441/161/890441161.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Sidi M'Hamed Ben Lahcen"
     ],
+    "name:ceb_x_preferred":[
+        "Sidi M Hamed Ben La"
+    ],
     "name:eng_x_preferred":[
         "Sidi M'Hamed Ben Lahcen"
     ],
@@ -42,6 +45,9 @@
         "Sidi M Hamed Ben La (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Sidi M'Hamed Ben Lahcen"
+    ],
+    "name:swe_x_preferred":[
         "Sidi M'Hamed Ben Lahcen"
     ],
     "qs:name":"Sidi M Hamed  Ben La",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890441161,
-    "wof:lastmodified":1669164198,
+    "wof:lastmodified":1690938972,
     "wof:name":"Sidi M Hamed Ben La",
     "wof:parent_id":890418103,
     "wof:placetype":"localadmin",

--- a/data/890/441/169/890441169.geojson
+++ b/data/890/441/169/890441169.geojson
@@ -28,6 +28,9 @@
     "name:ary_x_preferred":[
         "\u0645\u0637\u0631\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u0637\u0631\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0637\u0631\u0627\u0646"
     ],
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890441169,
-    "wof:lastmodified":1669164201,
+    "wof:lastmodified":1690938973,
     "wof:name":"Metrane",
     "wof:parent_id":1108784819,
     "wof:placetype":"localadmin",

--- a/data/890/441/171/890441171.geojson
+++ b/data/890/441/171/890441171.geojson
@@ -38,6 +38,9 @@
     "name:cat_x_preferred":[
         "M'Tal"
     ],
+    "name:ceb_x_preferred":[
+        "M Tal"
+    ],
     "name:eng_x_preferred":[
         "M'Tal"
     ],
@@ -55,6 +58,9 @@
         "M Tal (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "M'Tal"
+    ],
+    "name:swe_x_preferred":[
         "M'Tal"
     ],
     "qs:name":"M Tal",
@@ -89,7 +95,7 @@
         }
     ],
     "wof:id":890441171,
-    "wof:lastmodified":1669164201,
+    "wof:lastmodified":1690938984,
     "wof:name":"M Tal",
     "wof:parent_id":1108784819,
     "wof:placetype":"localadmin",

--- a/data/890/441/179/890441179.geojson
+++ b/data/890/441/179/890441179.geojson
@@ -56,6 +56,9 @@
     "name:ita_x_preferred":[
         "Tamda"
     ],
+    "name:swe_x_preferred":[
+        "Tamda"
+    ],
     "qs:name":"Tamda",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890441179,
-    "wof:lastmodified":1669164204,
+    "wof:lastmodified":1690938983,
     "wof:name":"Tamda",
     "wof:parent_id":1108784819,
     "wof:placetype":"localadmin",

--- a/data/890/441/193/890441193.geojson
+++ b/data/890/441/193/890441193.geojson
@@ -51,6 +51,9 @@
     "name:ita_x_preferred":[
         "Oulad Daoud Zkhanine"
     ],
+    "name:por_x_preferred":[
+        "Oulad Daoud Zkhanine"
+    ],
     "name:spa_x_preferred":[
         "Ulad Da\u00fad"
     ],
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":890441193,
-    "wof:lastmodified":1669164206,
+    "wof:lastmodified":1690938972,
     "wof:name":"Oulad Daoud Zkhanine",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/441/195/890441195.geojson
+++ b/data/890/441/195/890441195.geojson
@@ -47,6 +47,9 @@
     "name:ita_x_preferred":[
         "Oulad Settout"
     ],
+    "name:por_x_preferred":[
+        "Oulad Settout"
+    ],
     "name:spa_x_preferred":[
         "Ulad Settut"
     ],
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890441195,
-    "wof:lastmodified":1669164207,
+    "wof:lastmodified":1690938972,
     "wof:name":"Oulad Settout",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/441/205/890441205.geojson
+++ b/data/890/441/205/890441205.geojson
@@ -57,6 +57,9 @@
     "name:nld_x_preferred":[
         "Beni-Boughafer"
     ],
+    "name:por_x_preferred":[
+        "Bni Bouifrour"
+    ],
     "name:spa_x_preferred":[
         "Beni Buifrur"
     ],
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":890441205,
-    "wof:lastmodified":1669164211,
+    "wof:lastmodified":1690938976,
     "wof:name":"Bni Bouifrour",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/441/207/890441207.geojson
+++ b/data/890/441/207/890441207.geojson
@@ -68,6 +68,9 @@
     "name:nob_x_preferred":[
         "Bni Chiker"
     ],
+    "name:por_x_preferred":[
+        "Bni Chiker"
+    ],
     "name:rus_x_preferred":[
         "\u0425\u0430\u0434-\u0431\u0435\u043d\u0438-\u0428\u0438\u043a\u0435\u0440"
     ],
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":890441207,
-    "wof:lastmodified":1669164212,
+    "wof:lastmodified":1690938981,
     "wof:name":"Bni Chiker",
     "wof:parent_id":890455271,
     "wof:placetype":"localadmin",

--- a/data/890/441/209/890441209.geojson
+++ b/data/890/441/209/890441209.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u062e\u0645\u064a\u0633\u0627\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Khemisset"
+    ],
     "name:azb_x_preferred":[
         "\u062e\u0645\u06cc\u0633\u0627\u062a"
     ],
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":890441209,
-    "wof:lastmodified":1669164212,
+    "wof:lastmodified":1690938981,
     "wof:name":"Khemisset",
     "wof:parent_id":890453897,
     "wof:placetype":"localadmin",

--- a/data/890/441/441/890441441.geojson
+++ b/data/890/441/441/890441441.geojson
@@ -56,6 +56,9 @@
     "name:swe_x_preferred":[
         "Sidi Yahia el Gharb"
     ],
+    "name:swe_x_variant":[
+        "Sidi Yahya El Gharb"
+    ],
     "name:und_x_variant":[
         "Sidi Yahya du Rharb"
     ],
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":890441441,
-    "wof:lastmodified":1669164215,
+    "wof:lastmodified":1690938975,
     "wof:name":"Sidi Yahia el Gharb",
     "wof:parent_id":890427533,
     "wof:placetype":"locality",

--- a/data/890/442/529/890442529.geojson
+++ b/data/890/442/529/890442529.geojson
@@ -91,6 +91,9 @@
     "name:swe_x_preferred":[
         "Fahs-Anjra"
     ],
+    "name:tur_x_preferred":[
+        "Fahs-Encire"
+    ],
     "name:und_x_variant":[
         "\u0625\u0642\u0644\u064a\u0645 \u0627\u0644\u0641\u062d\u0635-\u0623\u0646\u062c\u0631\u0629"
     ],
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":890442529,
-    "wof:lastmodified":1669164221,
+    "wof:lastmodified":1690939098,
     "wof:name":"Fahs-Anjra",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/890/442/533/890442533.geojson
+++ b/data/890/442/533/890442533.geojson
@@ -57,6 +57,9 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627\u0621"
     ],
+    "name:arq_x_preferred":[
+        "\u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627"
+    ],
     "name:ary_x_preferred":[
         "\u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627"
     ],
@@ -485,7 +488,7 @@
         }
     ],
     "wof:id":890442533,
-    "wof:lastmodified":1669164222,
+    "wof:lastmodified":1690939098,
     "wof:name":"Casablanca",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/442/727/890442727.geojson
+++ b/data/890/442/727/890442727.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Issen"
     ],
+    "name:ceb_x_preferred":[
+        "Issen"
+    ],
     "name:eng_x_preferred":[
         "Issen"
     ],
@@ -42,6 +45,9 @@
         "Issen (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Issen"
+    ],
+    "name:swe_x_preferred":[
         "Issen"
     ],
     "qs:name":"Issen",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890442727,
-    "wof:lastmodified":1669164224,
+    "wof:lastmodified":1690939099,
     "wof:name":"Issen",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/444/503/890444503.geojson
+++ b/data/890/444/503/890444503.geojson
@@ -29,6 +29,9 @@
     "name:arz_x_preferred":[
         "\u062a\u064a\u0641\u0644\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Tiflet"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u06cc\u0641\u0644\u062a"
     ],
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":890444503,
-    "wof:lastmodified":1669164227,
+    "wof:lastmodified":1690939068,
     "wof:name":"Tiflet",
     "wof:parent_id":890453897,
     "wof:placetype":"locality",

--- a/data/890/444/505/890444505.geojson
+++ b/data/890/444/505/890444505.geojson
@@ -28,6 +28,9 @@
     "name:arz_x_preferred":[
         "\u0622\u0633\u0641\u0649"
     ],
+    "name:ast_x_preferred":[
+        "Safi"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0633\u0641\u06cc"
     ],
@@ -77,6 +80,9 @@
         "Asafi"
     ],
     "name:epo_x_preferred":[
+        "Safi"
+    ],
+    "name:est_x_preferred":[
         "Safi"
     ],
     "name:eus_x_preferred":[
@@ -363,7 +369,7 @@
         }
     ],
     "wof:id":890444505,
-    "wof:lastmodified":1669164228,
+    "wof:lastmodified":1690939068,
     "wof:name":"Safi",
     "wof:parent_id":890445397,
     "wof:placetype":"locality",

--- a/data/890/444/517/890444517.geojson
+++ b/data/890/444/517/890444517.geojson
@@ -32,6 +32,9 @@
     "name:arz_x_preferred":[
         "\u0648\u0627\u062f\u0649 \u0632\u0645"
     ],
+    "name:ast_x_preferred":[
+        "Oued Zem"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0627\u062f\u0632\u0645"
     ],
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":890444517,
-    "wof:lastmodified":1669164229,
+    "wof:lastmodified":1690939068,
     "wof:name":"Oued Zem",
     "wof:parent_id":890422519,
     "wof:placetype":"locality",

--- a/data/890/445/395/890445395.geojson
+++ b/data/890/445/395/890445395.geojson
@@ -100,6 +100,9 @@
     "name:swe_x_preferred":[
         "Taroudannt"
     ],
+    "name:tur_x_preferred":[
+        "Tarudant"
+    ],
     "name:zho_x_preferred":[
         "\u5854\u9b6f\u4e39\u7279\u7701"
     ],
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":890445395,
-    "wof:lastmodified":1669164283,
+    "wof:lastmodified":1690939103,
     "wof:name":"Taroudant",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/890/445/397/890445397.geojson
+++ b/data/890/445/397/890445397.geojson
@@ -100,6 +100,9 @@
     "name:swe_x_preferred":[
         "Safi"
     ],
+    "name:tur_x_preferred":[
+        "Asfi"
+    ],
     "name:und_x_variant":[
         "\u0625\u0642\u0644\u064a\u0645 \u0623\u0633\u0641\u064a",
         "Igl\u012bm \u0100saf\u012b"
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":890445397,
-    "wof:lastmodified":1669164392,
+    "wof:lastmodified":1690939101,
     "wof:name":"Safi",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/890/445/399/890445399.geojson
+++ b/data/890/445/399/890445399.geojson
@@ -104,6 +104,12 @@
     "name:swe_x_preferred":[
         "El-Jadida"
     ],
+    "name:swe_x_variant":[
+        "El Jadida"
+    ],
+    "name:tur_x_preferred":[
+        "El-Cedide"
+    ],
     "name:zho_x_preferred":[
         "\u5091\u8fea\u4ee3\u7701"
     ],
@@ -159,7 +165,7 @@
         }
     ],
     "wof:id":890445399,
-    "wof:lastmodified":1669164406,
+    "wof:lastmodified":1690939100,
     "wof:name":"El Jadida",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/445/509/890445509.geojson
+++ b/data/890/445/509/890445509.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Semguet"
     ],
+    "name:ceb_x_preferred":[
+        "Semguet"
+    ],
     "name:eng_x_preferred":[
         "Semguet"
     ],
@@ -42,6 +45,9 @@
         "Semguet (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Semguet"
+    ],
+    "name:swe_x_preferred":[
         "Semguet"
     ],
     "qs:name":"Semguet",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890445509,
-    "wof:lastmodified":1669164411,
+    "wof:lastmodified":1690939103,
     "wof:name":"Semguet",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/445/521/890445521.geojson
+++ b/data/890/445/521/890445521.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "A\u00eft Ouadrim"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Ouadrim"
+    ],
     "name:eng_x_preferred":[
         "Ait Ouadrim"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:ita_x_preferred":[
         "Ait Ouadrim"
+    ],
+    "name:swe_x_preferred":[
+        "A\u00eft Ouadrim"
     ],
     "qs:name":"Ait Ouadrim",
     "qs:photos_9r":0,
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890445521,
-    "wof:lastmodified":1669164414,
+    "wof:lastmodified":1690939101,
     "wof:name":"Ait Ouadrim",
     "wof:parent_id":1108784831,
     "wof:placetype":"localadmin",

--- a/data/890/445/527/890445527.geojson
+++ b/data/890/445/527/890445527.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u062a\u0627\u0631\u0648\u062f\u0627\u0646\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Taroudant"
+    ],
     "name:ben_x_preferred":[
         "\u09a4\u09be\u09b0\u09c1\u09a6\u09be\u09a8\u09cd\u09a4"
     ],
@@ -207,7 +210,7 @@
         }
     ],
     "wof:id":890445527,
-    "wof:lastmodified":1669164416,
+    "wof:lastmodified":1690939102,
     "wof:name":"Taroudant",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/445/529/890445529.geojson
+++ b/data/890/445/529/890445529.geojson
@@ -50,6 +50,9 @@
     "name:nld_x_preferred":[
         "Sidi Moumen"
     ],
+    "name:spa_x_preferred":[
+        "Sidi Moumen"
+    ],
     "name:swe_x_preferred":[
         "Sidi Moumen"
     ],
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890445529,
-    "wof:lastmodified":1669164417,
+    "wof:lastmodified":1690939102,
     "wof:name":"Sidi Moumen",
     "wof:parent_id":890442533,
     "wof:placetype":"localadmin",

--- a/data/890/445/533/890445533.geojson
+++ b/data/890/445/533/890445533.geojson
@@ -31,11 +31,17 @@
     "name:arz_x_preferred":[
         "\u0637\u0627\u0646\u0637\u0627\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Tan-Tan"
+    ],
     "name:azb_x_preferred":[
         "\u0637\u0627\u0646\u0637\u0627\u0646"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0422\u0430\u043d-\u0422\u0430\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u0422\u0430\u043d-\u0422\u0430\u043d"
     ],
     "name:ben_x_preferred":[
         "\u09a4\u09be\u09a8-\u09a4\u09be\u09a8"
@@ -209,7 +215,7 @@
         }
     ],
     "wof:id":890445533,
-    "wof:lastmodified":1669164418,
+    "wof:lastmodified":1690939100,
     "wof:name":"Tan Tan",
     "wof:parent_id":890418107,
     "wof:placetype":"localadmin",

--- a/data/890/445/551/890445551.geojson
+++ b/data/890/445/551/890445551.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Ait Hammou"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Hammou"
+    ],
     "name:eng_x_preferred":[
         "Ait Hammou"
     ],
@@ -51,6 +54,9 @@
         "\u05d0\u05d9\u05d9\u05d8 \u05d7\u05de\u05d5"
     ],
     "name:ita_x_preferred":[
+        "Ait Hammou"
+    ],
+    "name:swe_x_preferred":[
         "Ait Hammou"
     ],
     "qs:name":"Ait Hammou",
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890445551,
-    "wof:lastmodified":1669164422,
+    "wof:lastmodified":1690939099,
     "wof:name":"Ait Hammou",
     "wof:parent_id":1108784803,
     "wof:placetype":"localadmin",

--- a/data/890/452/779/890452779.geojson
+++ b/data/890/452/779/890452779.geojson
@@ -103,8 +103,17 @@
     "name:swe_x_preferred":[
         "Beni-Mellal"
     ],
+    "name:swe_x_variant":[
+        "B\u00e9ni Mellal"
+    ],
+    "name:tur_x_preferred":[
+        "Beni Mellal"
+    ],
     "name:und_x_variant":[
         "Iql\u012bm Ban\u012b Mal\u0101l"
+    ],
+    "name:uzb_x_preferred":[
+        "Beni-Mellal viloyati"
     ],
     "name:zho_x_preferred":[
         "\u8c9d\u5c3c\u9081\u62c9\u52d2\u7701"
@@ -159,7 +168,7 @@
         }
     ],
     "wof:id":890452779,
-    "wof:lastmodified":1669164429,
+    "wof:lastmodified":1690939019,
     "wof:name":"Beni Mellal",
     "wof:parent_id":1796661357,
     "wof:placetype":"county",

--- a/data/890/452/859/890452859.geojson
+++ b/data/890/452/859/890452859.geojson
@@ -56,6 +56,9 @@
     "name:swe_x_preferred":[
         "Ait Oumdis"
     ],
+    "name:uzb_x_preferred":[
+        "Ait Oumdis"
+    ],
     "qs:name":"Ait Oumdis",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890452859,
-    "wof:lastmodified":1669164431,
+    "wof:lastmodified":1690939017,
     "wof:name":"Ait Oumdis",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/452/865/890452865.geojson
+++ b/data/890/452/865/890452865.geojson
@@ -71,6 +71,9 @@
     "name:swe_x_preferred":[
         "Boudenib"
     ],
+    "name:swe_x_variant":[
+        "Boudnib"
+    ],
     "qs:name":"Boudnib",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":890452865,
-    "wof:lastmodified":1669164433,
+    "wof:lastmodified":1690939022,
     "wof:name":"Boudnib",
     "wof:parent_id":1108784773,
     "wof:placetype":"localadmin",

--- a/data/890/452/871/890452871.geojson
+++ b/data/890/452/871/890452871.geojson
@@ -63,6 +63,9 @@
     "name:swe_x_preferred":[
         "Ben Taieb"
     ],
+    "name:swe_x_variant":[
+        "Ben Ta\u00efeb"
+    ],
     "name:zho_x_preferred":[
         "\u672c-\u5854\u4f0a\u5e03"
     ],
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":890452871,
-    "wof:lastmodified":1669164434,
+    "wof:lastmodified":1690939022,
     "wof:name":"Ben Taieb",
     "wof:parent_id":1108784779,
     "wof:placetype":"localadmin",

--- a/data/890/452/889/890452889.geojson
+++ b/data/890/452/889/890452889.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Sidi M'Hamed Dalil"
     ],
+    "name:ceb_x_preferred":[
+        "Sidi M Hamed Dalil"
+    ],
     "name:eng_x_preferred":[
         "Sidi M'Hamed Dalil"
     ],
@@ -45,6 +48,9 @@
         "Sidi M Hamed Dalil (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Sidi M'Hamed Dalil"
+    ],
+    "name:swe_x_preferred":[
         "Sidi M'Hamed Dalil"
     ],
     "qs:name":"Sidi M Hamed Dalil",
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890452889,
-    "wof:lastmodified":1669164436,
+    "wof:lastmodified":1690939017,
     "wof:name":"Sidi M Hamed Dalil",
     "wof:parent_id":890440847,
     "wof:placetype":"localadmin",

--- a/data/890/452/907/890452907.geojson
+++ b/data/890/452/907/890452907.geojson
@@ -28,6 +28,9 @@
     "name:ary_x_preferred":[
         "\u0627\u0644\u0631\u06ad\u0627\u062f\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u0642\u0627\u062f\u0647"
+    ],
     "name:cat_x_preferred":[
         "Reggada"
     ],
@@ -50,6 +53,9 @@
     ],
     "name:shi_x_preferred":[
         "\u2d30\u2d55\u2d3b\u2d33\u2d30\u2d37\u2d30"
+    ],
+    "name:spa_x_preferred":[
+        "Reggada"
     ],
     "name:swe_x_preferred":[
         "Reggada"
@@ -86,7 +92,7 @@
         }
     ],
     "wof:id":890452907,
-    "wof:lastmodified":1669164441,
+    "wof:lastmodified":1690939015,
     "wof:name":"Reggada",
     "wof:parent_id":890428801,
     "wof:placetype":"localadmin",

--- a/data/890/452/913/890452913.geojson
+++ b/data/890/452/913/890452913.geojson
@@ -60,6 +60,9 @@
     "name:swe_x_preferred":[
         "M Hamid El Ghizlane"
     ],
+    "name:swe_x_variant":[
+        "M'Hamid El Ghizlane"
+    ],
     "qs:name":"M Hamid El Ghizlane",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":890452913,
-    "wof:lastmodified":1669164442,
+    "wof:lastmodified":1690939020,
     "wof:name":"M Hamid El Ghizlane",
     "wof:parent_id":890424149,
     "wof:placetype":"localadmin",

--- a/data/890/452/925/890452925.geojson
+++ b/data/890/452/925/890452925.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Sidi M'Hamed Chelh"
     ],
+    "name:ceb_x_preferred":[
+        "Sidi M Hamed Chelh"
+    ],
     "name:eng_x_preferred":[
         "Sidi M'Hamed Chelh"
     ],
@@ -42,6 +45,9 @@
         "Sidi M Hamed Chelh (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Sidi M'Hamed Chelh"
+    ],
+    "name:swe_x_preferred":[
         "Sidi M'Hamed Chelh"
     ],
     "qs:name":"Sidi M Hamed Chelh",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890452925,
-    "wof:lastmodified":1669164444,
+    "wof:lastmodified":1690939019,
     "wof:name":"Sidi M Hamed Chelh",
     "wof:parent_id":890429091,
     "wof:placetype":"localadmin",

--- a/data/890/452/931/890452931.geojson
+++ b/data/890/452/931/890452931.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Meskala"
     ],
+    "name:ceb_x_preferred":[
+        "Meskala"
+    ],
     "name:eng_x_preferred":[
         "Meskala"
     ],
@@ -42,6 +45,9 @@
         "Meskala (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Meskala"
+    ],
+    "name:swe_x_preferred":[
         "Meskala"
     ],
     "qs:name":"Meskala",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890452931,
-    "wof:lastmodified":1669164447,
+    "wof:lastmodified":1690939015,
     "wof:name":"Meskala",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/452/943/890452943.geojson
+++ b/data/890/452/943/890452943.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "M'Garto"
     ],
+    "name:ceb_x_preferred":[
+        "M Garto"
+    ],
     "name:eng_x_preferred":[
         "M'Garto"
     ],
@@ -42,6 +45,9 @@
         "M Garto (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "M'Garto"
+    ],
+    "name:swe_x_preferred":[
         "M'Garto"
     ],
     "qs:name":"M Garto",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890452943,
-    "wof:lastmodified":1669164451,
+    "wof:lastmodified":1690939023,
     "wof:name":"M Garto",
     "wof:parent_id":1108784833,
     "wof:placetype":"localadmin",

--- a/data/890/452/945/890452945.geojson
+++ b/data/890/452/945/890452945.geojson
@@ -23,7 +23,23 @@
         "\u0627\u0644\u062c\u062f\u064a\u062f\u0629 (\u0627\u0644\u0628\u0644\u062f\u064a\u0629)"
     ],
     "name:ara_x_variant":[
-        "\u0627\u0644\u0628\u0626\u0631 \u0627\u0644\u062c\u062f\u064a\u062f"
+        "\u0627\u0644\u0628\u0626\u0631 \u0627\u0644\u062c\u062f\u064a\u062f",
+        "\u0627\u0644\u0628\u064a\u0631 \u0627\u0644\u062c\u062f\u064a\u062f"
+    ],
+    "name:ary_x_preferred":[
+        "\u0644\u0628\u064a\u0631 \u062c\u062f\u064a\u062f"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0628\u064a\u0631 \u0627\u0644\u062c\u062f\u064a\u062f"
+    ],
+    "name:ast_x_preferred":[
+        "Bir Jdid"
+    ],
+    "name:azb_x_preferred":[
+        "\u0627\u0644\u0628\u06cc\u0631 \u0627\u0644\u062c\u062f\u06cc\u062f"
+    ],
+    "name:cat_x_preferred":[
+        "Bir Jdid"
     ],
     "name:ceb_x_preferred":[
         "Lbir Jdid"
@@ -31,18 +47,34 @@
     "name:eng_x_preferred":[
         "Lbir Jdid"
     ],
+    "name:eng_x_variant":[
+        "Bir Jdid"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0628\u06cc\u0631 \u0627\u0644\u062c\u062f\u06cc\u062f"
+    ],
     "name:fra_x_preferred":[
         "Lbir Jdid"
     ],
     "name:fra_x_variant":[
         "Lbir Jdid (MU)",
-        "Lbir Jdid (Commune Urbaine)"
+        "Lbir Jdid (Commune Urbaine)",
+        "Bir Jdid"
+    ],
+    "name:ita_x_preferred":[
+        "Bir Jdid"
     ],
     "name:nld_x_preferred":[
         "Lbir Jdid"
     ],
+    "name:nld_x_variant":[
+        "Bir Jdid"
+    ],
     "name:swe_x_preferred":[
         "Lbir Jdid"
+    ],
+    "name:zho_x_preferred":[
+        "\u6bd4\u5c14\u6770\u8fea\u5fb7"
     ],
     "qs:name":"Lbir Jdid",
     "qs:photos_9r":0,
@@ -76,7 +108,7 @@
         }
     ],
     "wof:id":890452945,
-    "wof:lastmodified":1669164452,
+    "wof:lastmodified":1690939023,
     "wof:name":"Lbir Jdid",
     "wof:parent_id":890445399,
     "wof:placetype":"localadmin",

--- a/data/890/452/947/890452947.geojson
+++ b/data/890/452/947/890452947.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Chtouka"
     ],
+    "name:ceb_x_preferred":[
+        "Chtouka"
+    ],
     "name:eng_x_preferred":[
         "Chtouka"
     ],
@@ -42,6 +45,9 @@
         "Chtouka (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Chtouka"
+    ],
+    "name:swe_x_preferred":[
         "Chtouka"
     ],
     "qs:name":"Chtouka",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890452947,
-    "wof:lastmodified":1669164453,
+    "wof:lastmodified":1690939019,
     "wof:name":"Chtouka",
     "wof:parent_id":890445399,
     "wof:placetype":"localadmin",

--- a/data/890/452/967/890452967.geojson
+++ b/data/890/452/967/890452967.geojson
@@ -44,6 +44,9 @@
     "name:swe_x_preferred":[
         "Tighza"
     ],
+    "name:swe_x_variant":[
+        "Thighza"
+    ],
     "qs:name":"Tighza",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":890452967,
-    "wof:lastmodified":1669156517,
+    "wof:lastmodified":1690939021,
     "wof:name":"Tighza",
     "wof:parent_id":1108784791,
     "wof:placetype":"localadmin",

--- a/data/890/452/977/890452977.geojson
+++ b/data/890/452/977/890452977.geojson
@@ -55,6 +55,9 @@
     "name:deu_x_preferred":[
         "Jbel Toubkal"
     ],
+    "name:deu_x_variant":[
+        "Tubqal"
+    ],
     "name:eng_x_preferred":[
         "Jbel Toubkal"
     ],
@@ -108,6 +111,9 @@
     "name:lit_x_preferred":[
         "Tubkalis"
     ],
+    "name:lld_x_preferred":[
+        "Jbel Toubkal"
+    ],
     "name:mkd_x_preferred":[
         "\u0422\u0443\u0431\u043a\u0430\u043b"
     ],
@@ -156,6 +162,9 @@
     "name:swe_x_preferred":[
         "Jbel Toubkal"
     ],
+    "name:tur_x_preferred":[
+        "Cebel Tubkal"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0443\u0431\u043a\u0430\u043b\u044c"
     ],
@@ -197,7 +206,7 @@
         }
     ],
     "wof:id":890452977,
-    "wof:lastmodified":1669164460,
+    "wof:lastmodified":1690939018,
     "wof:name":"Toubkal",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/452/979/890452979.geojson
+++ b/data/890/452/979/890452979.geojson
@@ -105,6 +105,9 @@
     "name:glg_x_preferred":[
         "Freia"
     ],
+    "name:glv_x_preferred":[
+        "Freyja"
+    ],
     "name:got_x_preferred":[
         "\ud800\udf46\ud800\udf42\ud800\udf30\ud800\udf3f\ud800\udf3e\ud800\udf49"
     ],
@@ -275,7 +278,7 @@
         }
     ],
     "wof:id":890452979,
-    "wof:lastmodified":1669164461,
+    "wof:lastmodified":1690939018,
     "wof:name":"Freija",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/452/993/890452993.geojson
+++ b/data/890/452/993/890452993.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Oued Rommane"
     ],
+    "name:eng_x_variant":[
+        "Ain Karma-Oued Rommane"
+    ],
     "name:fra_x_preferred":[
         "Oued Rommane"
     ],
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":890452993,
-    "wof:lastmodified":1669164465,
+    "wof:lastmodified":1690939020,
     "wof:name":"Oued Rommane",
     "wof:parent_id":1108784837,
     "wof:placetype":"localadmin",

--- a/data/890/453/567/890453567.geojson
+++ b/data/890/453/567/890453567.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Msied"
     ],
+    "name:ceb_x_preferred":[
+        "Msied"
+    ],
     "name:eng_x_preferred":[
         "Msied"
     ],
@@ -46,6 +49,9 @@
     ],
     "name:spa_x_preferred":[
         "Meseied"
+    ],
+    "name:swe_x_preferred":[
+        "Msied"
     ],
     "qs:name":"Msied",
     "qs:photos_9r":0,
@@ -79,7 +85,7 @@
         }
     ],
     "wof:id":890453567,
-    "wof:lastmodified":1669164472,
+    "wof:lastmodified":1690939042,
     "wof:name":"Msied",
     "wof:parent_id":890418107,
     "wof:placetype":"localadmin",

--- a/data/890/453/569/890453569.geojson
+++ b/data/890/453/569/890453569.geojson
@@ -28,6 +28,9 @@
     "name:ary_x_preferred":[
         "\u0623\u06af\u0648\u064a\u0646\u064a\u062a"
     ],
+    "name:ary_x_variant":[
+        "\u0623\u06ad\u0648\u0646\u064a\u062a"
+    ],
     "name:bul_x_preferred":[
         "\u0410\u0433\u0445\u043e\u0443\u0438\u043d\u0438\u0442\u0435"
     ],
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890453569,
-    "wof:lastmodified":1669164473,
+    "wof:lastmodified":1690939041,
     "wof:name":"Aghouinite",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/890/453/573/890453573.geojson
+++ b/data/890/453/573/890453573.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Ait Ouassif"
     ],
+    "name:ceb_x_preferred":[
+        "Ait Ouassif"
+    ],
     "name:eng_x_preferred":[
         "Ait Ouassif"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:ita_x_preferred":[
         "Ait Ouassif"
+    ],
+    "name:swe_x_preferred":[
+        "A\u00eft Ouassif"
     ],
     "qs:name":"Ait Ouassif",
     "qs:photos_9r":0,
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":890453573,
-    "wof:lastmodified":1669164474,
+    "wof:lastmodified":1690939044,
     "wof:name":"Ait Ouassif",
     "wof:parent_id":1108784839,
     "wof:placetype":"localadmin",

--- a/data/890/453/591/890453591.geojson
+++ b/data/890/453/591/890453591.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "M'Qam Tolba"
     ],
+    "name:ceb_x_preferred":[
+        "M Qam Tolba"
+    ],
     "name:eng_x_preferred":[
         "M'Qam Tolba"
     ],
@@ -42,6 +45,9 @@
         "M Qam Tolba (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "M'Qam Tolba"
+    ],
+    "name:swe_x_preferred":[
         "M'Qam Tolba"
     ],
     "qs:name":"M Qam Tolba",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890453591,
-    "wof:lastmodified":1669164479,
+    "wof:lastmodified":1690939045,
     "wof:name":"M Qam Tolba",
     "wof:parent_id":890453897,
     "wof:placetype":"localadmin",

--- a/data/890/453/593/890453593.geojson
+++ b/data/890/453/593/890453593.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u0639\u0648\u062f\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Ain Aouda"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0627\u0644\u0639\u0648\u062f\u0647"
     ],
@@ -75,6 +78,9 @@
     "name:swe_x_preferred":[
         "A\u00efn el Aouda"
     ],
+    "name:swe_x_variant":[
+        "A\u00efn El Aouda"
+    ],
     "qs:name":"Ain El Aouda",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -107,7 +113,7 @@
         }
     ],
     "wof:id":890453593,
-    "wof:lastmodified":1669164480,
+    "wof:lastmodified":1690939042,
     "wof:name":"Ain El Aouda",
     "wof:parent_id":890429101,
     "wof:placetype":"localadmin",

--- a/data/890/453/851/890453851.geojson
+++ b/data/890/453/851/890453851.geojson
@@ -94,6 +94,9 @@
     "name:swe_x_preferred":[
         "Tata"
     ],
+    "name:tur_x_preferred":[
+        "Tata"
+    ],
     "name:und_x_variant":[
         "Iql\u012bm \u0162\u0101\u0163\u0101"
     ],
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890453851,
-    "wof:lastmodified":1669164528,
+    "wof:lastmodified":1690939043,
     "wof:name":"Tata",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/890/453/883/890453883.geojson
+++ b/data/890/453/883/890453883.geojson
@@ -94,6 +94,12 @@
     "name:swe_x_preferred":[
         "Chefchaouen Province"
     ],
+    "name:swe_x_variant":[
+        "Chefchaouen"
+    ],
+    "name:tur_x_preferred":[
+        "\u015eaf\u015favan"
+    ],
     "name:ukr_x_preferred":[
         "\u0428\u0430\u0444\u0448\u0430\u0432\u0430\u043d"
     ],
@@ -156,7 +162,7 @@
         }
     ],
     "wof:id":890453883,
-    "wof:lastmodified":1669164545,
+    "wof:lastmodified":1690939045,
     "wof:name":"Chefchaouen",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/890/453/895/890453895.geojson
+++ b/data/890/453/895/890453895.geojson
@@ -99,6 +99,9 @@
     "name:swe_x_preferred":[
         "Oujda-Angad"
     ],
+    "name:tur_x_preferred":[
+        "Vecde-Enkad"
+    ],
     "name:und_x_variant":[
         "\u0639\u0645\u0627\u0644\u0629 \u0648\u062c\u062f\u0629 - \u0623\u0646\u062c\u0627\u062f",
         "Igl\u012bm Wajdah"
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":890453895,
-    "wof:lastmodified":1669164553,
+    "wof:lastmodified":1690939043,
     "wof:name":"Oujda-Angad",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/890/453/897/890453897.geojson
+++ b/data/890/453/897/890453897.geojson
@@ -95,6 +95,12 @@
     "name:swe_x_preferred":[
         "Khemisset"
     ],
+    "name:swe_x_variant":[
+        "Kh\u00e9misset"
+    ],
+    "name:tur_x_preferred":[
+        "Hamiset"
+    ],
     "name:und_x_variant":[
         "Kimisset"
     ],
@@ -153,7 +159,7 @@
         }
     ],
     "wof:id":890453897,
-    "wof:lastmodified":1669164565,
+    "wof:lastmodified":1690939045,
     "wof:name":"Khemisset",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/890/453/939/890453939.geojson
+++ b/data/890/453/939/890453939.geojson
@@ -107,6 +107,12 @@
     "name:spa_x_preferred":[
         "Provincia de Esauira"
     ],
+    "name:swe_x_preferred":[
+        "Essaouira"
+    ],
+    "name:tur_x_preferred":[
+        "Suveyre"
+    ],
     "name:und_x_variant":[
         "\u0625\u0642\u0644\u064a\u0645 \u0627\u0644\u0635\u0648\u064a\u0631\u0629\u200e",
         "Iql\u012bm A\u015f \u015eaw\u012brah"
@@ -170,7 +176,7 @@
         }
     ],
     "wof:id":890453939,
-    "wof:lastmodified":1669164618,
+    "wof:lastmodified":1690939043,
     "wof:name":"Essaouira",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/890/454/085/890454085.geojson
+++ b/data/890/454/085/890454085.geojson
@@ -29,6 +29,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0635\u062e\u064a\u0631\u0627\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Skhirat"
+    ],
     "name:azb_x_preferred":[
         "\u0635\u062e\u06cc\u0631\u0627\u062a"
     ],
@@ -77,6 +80,9 @@
     "name:und_x_variant":[
         "A\u00e7 \u00c7khirat"
     ],
+    "name:urd_x_preferred":[
+        "\u0635\u062e\u06cc\u0631\u0627\u062a"
+    ],
     "name:zho_x_preferred":[
         "\u65af\u57fa\u62c9\u7279"
     ],
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":890454085,
-    "wof:lastmodified":1669164619,
+    "wof:lastmodified":1690939036,
     "wof:name":"Skhirat",
     "wof:parent_id":890429101,
     "wof:placetype":"locality",

--- a/data/890/454/211/890454211.geojson
+++ b/data/890/454/211/890454211.geojson
@@ -56,6 +56,9 @@
     "name:swe_x_preferred":[
         "Zaouiat Ahansal"
     ],
+    "name:uzb_x_preferred":[
+        "Zaouiat Ahansal"
+    ],
     "name:zho_x_preferred":[
         "\u624e\u4e4c\u4e9a\u7279\u963f\u6c49\u8428\u5c14"
     ],
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890454211,
-    "wof:lastmodified":1669164620,
+    "wof:lastmodified":1690939034,
     "wof:name":"Zaouiat Ahansal",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/454/215/890454215.geojson
+++ b/data/890/454/215/890454215.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Sidi M'Hamed Akhdim"
     ],
+    "name:ceb_x_preferred":[
+        "Sidi M Hamed Akhdim"
+    ],
     "name:eng_x_preferred":[
         "Sidi M'Hamed Akhdim"
     ],
@@ -42,6 +45,9 @@
         "Sidi M Hamed Akhdim (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Sidi M'Hamed Akhdim"
+    ],
+    "name:swe_x_preferred":[
         "Sidi M'Hamed Akhdim"
     ],
     "qs:name":"Sidi M Hamed  Akhdim",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890454215,
-    "wof:lastmodified":1669164621,
+    "wof:lastmodified":1690939039,
     "wof:name":"Sidi M Hamed Akhdim",
     "wof:parent_id":890445399,
     "wof:placetype":"localadmin",

--- a/data/890/454/217/890454217.geojson
+++ b/data/890/454/217/890454217.geojson
@@ -47,6 +47,12 @@
     "name:ita_x_preferred":[
         "Talgjount"
     ],
+    "name:por_x_preferred":[
+        "Talgjount"
+    ],
+    "name:spa_x_preferred":[
+        "Talgjount"
+    ],
     "name:swe_x_preferred":[
         "Talgjount"
     ],
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":890454217,
-    "wof:lastmodified":1669164622,
+    "wof:lastmodified":1690939036,
     "wof:name":"Talgjount",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/454/219/890454219.geojson
+++ b/data/890/454/219/890454219.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Tigouga"
     ],
+    "name:ceb_x_preferred":[
+        "Tigouga"
+    ],
     "name:eng_x_preferred":[
         "Tigouga"
     ],
@@ -42,6 +45,9 @@
         "Tigouga (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Tigouga"
+    ],
+    "name:swe_x_preferred":[
         "Tigouga"
     ],
     "qs:name":"Tigouga",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890454219,
-    "wof:lastmodified":1669164623,
+    "wof:lastmodified":1690939035,
     "wof:name":"Tigouga",
     "wof:parent_id":890445395,
     "wof:placetype":"localadmin",

--- a/data/890/454/227/890454227.geojson
+++ b/data/890/454/227/890454227.geojson
@@ -28,6 +28,9 @@
     "name:cat_x_preferred":[
         "Hay Hassani"
     ],
+    "name:ceb_x_preferred":[
+        "Hay-Hassani"
+    ],
     "name:deu_x_preferred":[
         "Hay Hassani"
     ],
@@ -43,6 +46,9 @@
     ],
     "name:nld_x_preferred":[
         "Hay Hassani"
+    ],
+    "name:swe_x_preferred":[
+        "Hay-Hassani"
     ],
     "qs:name":"Hay-Hassani",
     "qs:photos_9r":0,
@@ -78,7 +84,7 @@
         }
     ],
     "wof:id":890454227,
-    "wof:lastmodified":1669164625,
+    "wof:lastmodified":1690939034,
     "wof:name":"Hay-Hassani",
     "wof:parent_id":890442533,
     "wof:placetype":"localadmin",

--- a/data/890/454/229/890454229.geojson
+++ b/data/890/454/229/890454229.geojson
@@ -25,10 +25,16 @@
     "name:ara_x_variant":[
         "\u0645\u0642\u0627\u0637\u0639\u0629 \u0627\u0644\u062d\u064a \u0627\u0644\u0645\u062d\u0645\u062f\u064a"
     ],
+    "name:bar_x_preferred":[
+        "Hay Mohammadi"
+    ],
     "name:cat_x_preferred":[
         "Hay Mohammadi"
     ],
     "name:ceb_x_preferred":[
+        "Hay Mohammadi"
+    ],
+    "name:deu_x_preferred":[
         "Hay Mohammadi"
     ],
     "name:eng_x_preferred":[
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890454229,
-    "wof:lastmodified":1669164625,
+    "wof:lastmodified":1690939034,
     "wof:name":"Hay Mohammadi",
     "wof:parent_id":890442533,
     "wof:placetype":"localadmin",

--- a/data/890/454/233/890454233.geojson
+++ b/data/890/454/233/890454233.geojson
@@ -28,6 +28,9 @@
     "name:cat_x_preferred":[
         "Mers Sultan"
     ],
+    "name:ceb_x_preferred":[
+        "Mers-Sultan"
+    ],
     "name:eng_x_preferred":[
         "Mers Sultan"
     ],
@@ -41,6 +44,9 @@
     ],
     "name:gle_x_preferred":[
         "Mers Sultan"
+    ],
+    "name:swe_x_preferred":[
+        "Mers-Sultan"
     ],
     "qs:name":"Mers-Sultan",
     "qs:photos_9r":0,
@@ -74,7 +80,7 @@
         }
     ],
     "wof:id":890454233,
-    "wof:lastmodified":1669164626,
+    "wof:lastmodified":1690939037,
     "wof:name":"Mers-Sultan",
     "wof:parent_id":890442533,
     "wof:placetype":"localadmin",

--- a/data/890/454/255/890454255.geojson
+++ b/data/890/454/255/890454255.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Anougal"
     ],
+    "name:ceb_x_preferred":[
+        "Anougal"
+    ],
     "name:eng_x_preferred":[
         "Anougal"
     ],
@@ -48,6 +51,9 @@
         "Anougal (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Anougal"
+    ],
+    "name:swe_x_preferred":[
         "Anougal"
     ],
     "name:urd_x_preferred":[
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":890454255,
-    "wof:lastmodified":1669164633,
+    "wof:lastmodified":1690939040,
     "wof:name":"Anougal",
     "wof:parent_id":1108784801,
     "wof:placetype":"localadmin",

--- a/data/890/454/263/890454263.geojson
+++ b/data/890/454/263/890454263.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Tafraout"
     ],
+    "name:ceb_x_preferred":[
+        "Tafraout"
+    ],
     "name:dan_x_preferred":[
         "Tafraout"
     ],
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":890454263,
-    "wof:lastmodified":1669164635,
+    "wof:lastmodified":1690939040,
     "wof:name":"Tafraout",
     "wof:parent_id":890428801,
     "wof:placetype":"localadmin",

--- a/data/890/454/283/890454283.geojson
+++ b/data/890/454/283/890454283.geojson
@@ -89,6 +89,9 @@
     "name:swe_x_preferred":[
         "Beni Enzar"
     ],
+    "name:swe_x_variant":[
+        "Bni Ansar"
+    ],
     "name:zho_x_preferred":[
         "\u8c9d\u5c3c-\u5b89\u85a9\u723e"
     ],
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":890454283,
-    "wof:lastmodified":1669164637,
+    "wof:lastmodified":1690939038,
     "wof:name":"Bni Ansar",
     "wof:parent_id":1796661375,
     "wof:placetype":"localadmin",

--- a/data/890/454/291/890454291.geojson
+++ b/data/890/454/291/890454291.geojson
@@ -51,6 +51,9 @@
     "name:swe_x_preferred":[
         "Oulad Said L Oued"
     ],
+    "name:swe_x_variant":[
+        "Oulad Said L'Oued"
+    ],
     "name:zgh_x_preferred":[
         "\u2d30\u2d61\u2d4d\u2d30\u2d37 \u2d59\u2d44\u2d49\u2d37 \u2d4d\u2d61\u2d30\u2d37"
     ],
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":890454291,
-    "wof:lastmodified":1669164640,
+    "wof:lastmodified":1690939039,
     "wof:name":"Oulad Said L Oued",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/454/301/890454301.geojson
+++ b/data/890/454/301/890454301.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Ida Ou Guelloul"
     ],
+    "name:ceb_x_preferred":[
+        "Ida Ou Guelloul"
+    ],
     "name:eng_x_preferred":[
         "Ida Ou Guelloul"
     ],
@@ -42,6 +45,9 @@
         "Ida Ou Guelloul (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Ida Ou Guelloul"
+    ],
+    "name:swe_x_preferred":[
         "Ida Ou Guelloul"
     ],
     "qs:name":"Ida Ou Guelloul",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890454301,
-    "wof:lastmodified":1669164644,
+    "wof:lastmodified":1690939034,
     "wof:name":"Ida Ou Guelloul",
     "wof:parent_id":890453939,
     "wof:placetype":"localadmin",

--- a/data/890/454/307/890454307.geojson
+++ b/data/890/454/307/890454307.geojson
@@ -50,6 +50,9 @@
     "name:swe_x_preferred":[
         "Foum Oudi"
     ],
+    "name:uzb_x_preferred":[
+        "Foum Oudi"
+    ],
     "qs:name":"Foum Oudi",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890454307,
-    "wof:lastmodified":1669164646,
+    "wof:lastmodified":1690939033,
     "wof:name":"Foum Oudi",
     "wof:parent_id":1108784827,
     "wof:placetype":"localadmin",

--- a/data/890/454/309/890454309.geojson
+++ b/data/890/454/309/890454309.geojson
@@ -67,6 +67,9 @@
     "name:swe_x_preferred":[
         "Dar Ould Zidouh"
     ],
+    "name:uzb_x_preferred":[
+        "Dar Oulad Ziduh"
+    ],
     "qs:name":"Dar Ould Zidouh",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890454309,
-    "wof:lastmodified":1669164646,
+    "wof:lastmodified":1690939033,
     "wof:name":"Dar Ould Zidouh",
     "wof:parent_id":1108784787,
     "wof:placetype":"localadmin",

--- a/data/890/454/315/890454315.geojson
+++ b/data/890/454/315/890454315.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Taghzirt"
     ],
+    "name:ceb_x_preferred":[
+        "Taghzirt"
+    ],
     "name:eng_x_preferred":[
         "Taghzirt"
     ],
@@ -42,6 +45,9 @@
         "Taghzirt (Commune Rurale)"
     ],
     "name:ita_x_preferred":[
+        "Taghzirt"
+    ],
+    "name:swe_x_preferred":[
         "Taghzirt"
     ],
     "qs:name":"Taghzirt",
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890454315,
-    "wof:lastmodified":1669164649,
+    "wof:lastmodified":1690939037,
     "wof:name":"Taghzirt",
     "wof:parent_id":890452779,
     "wof:placetype":"localadmin",

--- a/data/890/454/319/890454319.geojson
+++ b/data/890/454/319/890454319.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "M'Saada"
     ],
+    "name:ceb_x_preferred":[
+        "M Saada"
+    ],
     "name:eng_x_preferred":[
         "M'Saada"
     ],
@@ -43,6 +46,9 @@
         "M'Saada"
     ],
     "name:ita_x_preferred":[
+        "M'Saada"
+    ],
+    "name:swe_x_preferred":[
         "M'Saada"
     ],
     "qs:name":"M Saada",
@@ -77,7 +83,7 @@
         }
     ],
     "wof:id":890454319,
-    "wof:lastmodified":1669164651,
+    "wof:lastmodified":1690939041,
     "wof:name":"M Saada",
     "wof:parent_id":1108784809,
     "wof:placetype":"localadmin",

--- a/data/890/454/333/890454333.geojson
+++ b/data/890/454/333/890454333.geojson
@@ -58,6 +58,9 @@
     "name:cat_x_preferred":[
         "Prefectura de Fes"
     ],
+    "name:ceb_x_preferred":[
+        "Fes"
+    ],
     "name:dan_x_preferred":[
         "Fez"
     ],
@@ -143,6 +146,9 @@
     ],
     "name:swe_x_preferred":[
         "Fez"
+    ],
+    "name:swe_x_variant":[
+        "F\u00e8s"
     ],
     "name:tam_x_preferred":[
         "\u0baa\u0bc6\u0bb8\u0bcd"
@@ -232,7 +238,7 @@
         }
     ],
     "wof:id":890454333,
-    "wof:lastmodified":1669164655,
+    "wof:lastmodified":1690939038,
     "wof:name":"Fes",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/269/890455269.geojson
+++ b/data/890/455/269/890455269.geojson
@@ -28,6 +28,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0646\u0648\u0627\u0635\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Nouaceur"
+    ],
     "name:bul_x_preferred":[
         "\u041d\u043e\u0443\u0430\u0441\u0435\u0443\u0440"
     ],
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":890455269,
-    "wof:lastmodified":1669164656,
+    "wof:lastmodified":1690939024,
     "wof:name":"Nouaseur",
     "wof:parent_id":890424145,
     "wof:placetype":"locality",

--- a/data/890/455/271/890455271.geojson
+++ b/data/890/455/271/890455271.geojson
@@ -109,6 +109,9 @@
     "name:swe_x_preferred":[
         "Nador"
     ],
+    "name:tur_x_preferred":[
+        "Nazur"
+    ],
     "name:und_x_variant":[
         "Iql\u012bm an N\u0101\u1e11awr"
     ],
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":890455271,
-    "wof:lastmodified":1669164666,
+    "wof:lastmodified":1690939025,
     "wof:name":"Nador",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/890/455/417/890455417.geojson
+++ b/data/890/455/417/890455417.geojson
@@ -31,6 +31,9 @@
     "name:cat_x_preferred":[
         "Smi\u00e0"
     ],
+    "name:ceb_x_preferred":[
+        "Smia"
+    ],
     "name:eng_x_preferred":[
         "Smi\u00e0"
     ],
@@ -47,6 +50,9 @@
     ],
     "name:spa_x_preferred":[
         "Smi\u00e0"
+    ],
+    "name:swe_x_preferred":[
+        "Smia"
     ],
     "qs:name":"Smia",
     "qs:photos_9r":0,
@@ -80,7 +86,7 @@
         }
     ],
     "wof:id":890455417,
-    "wof:lastmodified":1669164667,
+    "wof:lastmodified":1690939024,
     "wof:name":"Smia",
     "wof:parent_id":890436791,
     "wof:placetype":"localadmin",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.