### PR TITLE
ma concordances, placetype local, and more

### DIFF
--- a/data/110/878/477/1/1108784771.geojson
+++ b/data/110/878/477/1/1108784771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.177946,
-    "geom:area_square_m":1805608520.104106,
+    "geom:area_square_m":1805608623.07564,
     "geom:bbox":"-2.802923,34.589625,-2.059646,35.127425",
     "geom:latitude":34.854343,
     "geom:longitude":-2.402183,
@@ -129,9 +129,10 @@
         "hasc:id":"MA.OF.BE",
         "wd:id":"Q820802"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827677,
-    "wof:geomhash":"6e9770551c80975c7e7b0566fc1eb6a7",
+    "wof:geomhash":"226dfa80bbfb68cdd8c2bdd06cc6f4de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108784771,
-    "wof:lastmodified":1690938913,
+    "wof:lastmodified":1695886562,
     "wof:name":"Berkane",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/110/878/477/3/1108784773.geojson
+++ b/data/110/878/477/3/1108784773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.546718,
-    "geom:area_square_m":26892633803.802845,
+    "geom:area_square_m":26892633634.175297,
     "geom:bbox":"-5.516581,30.012038,-3.121934,32.262935",
     "geom:latitude":31.347832,
     "geom:longitude":-4.34048,
@@ -132,9 +132,10 @@
         "hasc:id":"MA.DT.ER",
         "wd:id":"Q2024447"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827678,
-    "wof:geomhash":"9889c89ba3272884065ee0c414d7f711",
+    "wof:geomhash":"bc9e986d2b5ec798faf22620df3d9978",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108784773,
-    "wof:lastmodified":1690938914,
+    "wof:lastmodified":1695886560,
     "wof:name":"Errachidia",
     "wof:parent_id":1796661363,
     "wof:placetype":"county",

--- a/data/110/878/477/5/1108784775.geojson
+++ b/data/110/878/477/5/1108784775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.678225,
-    "geom:area_square_m":6949200113.576284,
+    "geom:area_square_m":6949199852.276723,
     "geom:bbox":"-2.671644,33.635004,-1.64607,34.584422",
     "geom:latitude":34.041203,
     "geom:longitude":-2.101772,
@@ -123,9 +123,10 @@
         "hasc:id":"MA.OF.JE",
         "wd:id":"Q1687516"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827680,
-    "wof:geomhash":"fa2642b7f1af13803f8863e016429e96",
+    "wof:geomhash":"e0e6f62062c695adb9308bfb053608e2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108784775,
-    "wof:lastmodified":1690938914,
+    "wof:lastmodified":1695886563,
     "wof:name":"Jerada",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/110/878/477/7/1108784777.geojson
+++ b/data/110/878/477/7/1108784777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021937,
-    "geom:area_square_m":220162172.948564,
+    "geom:area_square_m":220161664.437741,
     "geom:bbox":"-5.460201,35.598249,-5.274583,35.922687",
     "geom:latitude":35.742238,
     "geom:longitude":-5.379076,
@@ -106,9 +106,10 @@
         "hasc:id":"MA.TC.MF",
         "wd:id":"Q3408887"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827682,
-    "wof:geomhash":"a3648e49b19323fd686d5098291fb3a8",
+    "wof:geomhash":"9b1f29ae784c400d04b9b0ebb8e4cdb2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108784777,
-    "wof:lastmodified":1690938913,
+    "wof:lastmodified":1695886564,
     "wof:name":"M'diq-Fnideq",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/110/878/477/9/1108784779.geojson
+++ b/data/110/878/477/9/1108784779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.296722,
-    "geom:area_square_m":3006836844.075304,
+    "geom:area_square_m":3006836853.787485,
     "geom:bbox":"-3.828785,34.54013,-3.169769,35.290417",
     "geom:latitude":34.962843,
     "geom:longitude":-3.508791,
@@ -117,9 +117,10 @@
         "hasc:id":"MA.OF.DR",
         "wd:id":"Q1440552"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827685,
-    "wof:geomhash":"df1637d8d336cbb9e3c57a4f55bd779f",
+    "wof:geomhash":"d50b69cd73aa14b1b4bcf58ebac3d337",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108784779,
-    "wof:lastmodified":1690938913,
+    "wof:lastmodified":1695886562,
     "wof:name":"Driouch",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/110/878/478/3/1108784783.geojson
+++ b/data/110/878/478/3/1108784783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105376,
-    "geom:area_square_m":1059893975.713594,
+    "geom:area_square_m":1059893883.190813,
     "geom:bbox":"-6.11138,35.30051,-5.701571,35.820138",
     "geom:latitude":35.567723,
     "geom:longitude":-5.895059,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"MA.TC.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827686,
-    "wof:geomhash":"5fda7b345ea6d42f56c51925922c32fb",
+    "wof:geomhash":"9048e1a16d61965c503ea6f167bba1f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108784783,
-    "wof:lastmodified":1669161174,
+    "wof:lastmodified":1695886564,
     "wof:name":"Tanger-Assilah",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/110/878/478/5/1108784785.geojson
+++ b/data/110/878/478/5/1108784785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.392418,
-    "geom:area_square_m":4112107691.693383,
+    "geom:area_square_m":4112108279.499186,
     "geom:bbox":"-7.761755,31.620963,-7.004539,32.468659",
     "geom:latitude":32.063802,
     "geom:longitude":-7.384818,
@@ -132,9 +132,10 @@
         "hasc:id":"MA.MS.EK",
         "wd:id":"Q970179"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827688,
-    "wof:geomhash":"c3300568ba1ddc7508967adedd8761c0",
+    "wof:geomhash":"edbc9c75b9e2e2601af4be350e62cd8b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108784785,
-    "wof:lastmodified":1690938911,
+    "wof:lastmodified":1695886561,
     "wof:name":"El Kelaat Es-Sraghna",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/110/878/478/7/1108784787.geojson
+++ b/data/110/878/478/7/1108784787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.235554,
-    "geom:area_square_m":2458788642.492719,
+    "geom:area_square_m":2458788816.966494,
     "geom:bbox":"-7.124218,32.167155,-6.424624,32.67177",
     "geom:latitude":32.416779,
     "geom:longitude":-6.784169,
@@ -114,9 +114,10 @@
         "hasc:id":"MA.BK.FB",
         "wd:id":"Q3408359"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827690,
-    "wof:geomhash":"312990d125baa68bcd005adeb007f124",
+    "wof:geomhash":"2c71f70531b09a194a5d86d85248c109",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108784787,
-    "wof:lastmodified":1690938911,
+    "wof:lastmodified":1695886558,
     "wof:name":"Fquih Ben Saleh",
     "wof:parent_id":1796661357,
     "wof:placetype":"county",

--- a/data/110/878/478/9/1108784789.geojson
+++ b/data/110/878/478/9/1108784789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.208882,
-    "geom:area_square_m":2148981151.590749,
+    "geom:area_square_m":2148981779.72997,
     "geom:bbox":"-5.816635,33.380863,-5.067502,33.999573",
     "geom:latitude":33.693727,
     "geom:longitude":-5.466531,
@@ -123,9 +123,10 @@
         "hasc:id":"MA.FK.EH",
         "wd:id":"Q2540509"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827692,
-    "wof:geomhash":"b5222dd448a52540769b588c9e0729b1",
+    "wof:geomhash":"c6edbe5d6ce5281a4099825c7d575cb1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108784789,
-    "wof:lastmodified":1690938911,
+    "wof:lastmodified":1695886561,
     "wof:name":"El Hajeb",
     "wof:parent_id":1796661365,
     "wof:placetype":"county",

--- a/data/110/878/479/1/1108784791.geojson
+++ b/data/110/878/479/1/1108784791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.648889,
-    "geom:area_square_m":6728815215.119559,
+    "geom:area_square_m":6728815056.296185,
     "geom:bbox":"-6.419399,32.450901,-5.242969,33.479693",
     "geom:latitude":33.004206,
     "geom:longitude":-5.764298,
@@ -117,9 +117,10 @@
         "hasc:id":"MA.BK.KF",
         "wd:id":"Q1820589"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827693,
-    "wof:geomhash":"10739e466e62b7c4053b6497e932f6c8",
+    "wof:geomhash":"1f3e6b256efd515cdf9a78351d8740aa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108784791,
-    "wof:lastmodified":1690938916,
+    "wof:lastmodified":1695886559,
     "wof:name":"Khenifra",
     "wof:parent_id":1796661357,
     "wof:placetype":"county",

--- a/data/110/878/479/3/1108784793.geojson
+++ b/data/110/878/479/3/1108784793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.245709,
-    "geom:area_square_m":2540958043.324963,
+    "geom:area_square_m":2540958482.099127,
     "geom:bbox":"-8.124608,33.009649,-7.216404,33.513133",
     "geom:latitude":33.245522,
     "geom:longitude":-7.695992,
@@ -117,9 +117,10 @@
         "hasc:id":"MA.CS.BR",
         "wd:id":"Q2395317"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827694,
-    "wof:geomhash":"281af98990e91a2f7b4dd243bfe08d20",
+    "wof:geomhash":"edce7626f9a2ba4a1a862bce694846ed",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108784793,
-    "wof:lastmodified":1690938916,
+    "wof:lastmodified":1695886559,
     "wof:name":"Berrechid",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/110/878/479/5/1108784795.geojson
+++ b/data/110/878/479/5/1108784795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.218668,
-    "geom:area_square_m":12717330496.993168,
+    "geom:area_square_m":12717331185.297907,
     "geom:bbox":"-5.888746,31.873512,-3.788877,33.092132",
     "geom:latitude":32.440925,
     "geom:longitude":-4.817296,
@@ -111,9 +111,10 @@
         "hasc:id":"MA.DT.MI",
         "wd:id":"Q3408385"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827697,
-    "wof:geomhash":"8c360fbefd3da05fee84c0722a743215",
+    "wof:geomhash":"920c5a0f050cd001676c1b8b13005acb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108784795,
-    "wof:lastmodified":1690938917,
+    "wof:lastmodified":1695886560,
     "wof:name":"Midelt",
     "wof:parent_id":1796661363,
     "wof:placetype":"county",

--- a/data/110/878/479/7/1108784797.geojson
+++ b/data/110/878/479/7/1108784797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.211153,
-    "geom:area_square_m":2144051398.376046,
+    "geom:area_square_m":2144051416.4593,
     "geom:bbox":"-5.790806,34.513325,-5.146125,35.04161",
     "geom:latitude":34.79697,
     "geom:longitude":-5.449498,
@@ -144,9 +144,10 @@
         "hasc:id":"MA.TC.OU",
         "wd:id":"Q3408330"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827698,
-    "wof:geomhash":"0694c84df7d99c8d47d73953ac87808b",
+    "wof:geomhash":"a80a78eb4afb7aefc785a61f0ddfc1d7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":1108784797,
-    "wof:lastmodified":1690938916,
+    "wof:lastmodified":1695886564,
     "wof:name":"Ouezzane",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/110/878/480/1/1108784801.geojson
+++ b/data/110/878/480/1/1108784801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.575745,
-    "geom:area_square_m":6083259457.605628,
+    "geom:area_square_m":6083259621.513334,
     "geom:bbox":"-8.662542,30.861066,-7.129725,31.689901",
     "geom:latitude":31.296365,
     "geom:longitude":-7.874224,
@@ -150,9 +150,10 @@
         "hasc:id":"MA.MS.AH",
         "wd:id":"Q2150989"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827699,
-    "wof:geomhash":"3d0e6d7926268453b13ec0f1e0dd72c9",
+    "wof:geomhash":"cb1d44efd35388ab65e5890b89dab601",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1108784801,
-    "wof:lastmodified":1690938918,
+    "wof:lastmodified":1695886562,
     "wof:name":"Al Haouz",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/110/878/480/3/1108784803.geojson
+++ b/data/110/878/480/3/1108784803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.527353,
-    "geom:area_square_m":5517821601.804461,
+    "geom:area_square_m":5517821803.778568,
     "geom:bbox":"-8.479544,31.621536,-7.539146,32.814163",
     "geom:latitude":32.199834,
     "geom:longitude":-7.933692,
@@ -117,9 +117,10 @@
         "hasc:id":"MA.MS.RE",
         "wd:id":"Q3408399"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827701,
-    "wof:geomhash":"06d033271b4eff7801f19354a65798d8",
+    "wof:geomhash":"a297a985517b49e996dfd4f19b47854d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108784803,
-    "wof:lastmodified":1690938919,
+    "wof:lastmodified":1695886561,
     "wof:name":"Rhamna",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/110/878/480/5/1108784805.geojson
+++ b/data/110/878/480/5/1108784805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.145037,
-    "geom:area_square_m":1484329301.084502,
+    "geom:area_square_m":1484329292.132614,
     "geom:bbox":"-5.426341,33.902766,-4.751771,34.315517",
     "geom:latitude":34.141245,
     "geom:longitude":-5.078828,
@@ -121,9 +121,10 @@
         "hasc:id":"MA.FK.ZM",
         "wd:id":"Q1950226"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827702,
-    "wof:geomhash":"20b474402ceb1e8fdbbfb0d51969c50d",
+    "wof:geomhash":"4fe43bf25e8d085bf100af0cf173d9e1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108784805,
-    "wof:lastmodified":1690938919,
+    "wof:lastmodified":1695886564,
     "wof:name":"Moulay Yacoub",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/878/480/7/1108784807.geojson
+++ b/data/110/878/480/7/1108784807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.701738,
-    "geom:area_square_m":7178778597.56622,
+    "geom:area_square_m":7178779187.346254,
     "geom:bbox":"-4.120248,33.512868,-2.939544,34.769385",
     "geom:latitude":34.174179,
     "geom:longitude":-3.514161,
@@ -111,9 +111,10 @@
         "hasc:id":"MA.OF.GU",
         "wd:id":"Q3408363"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827703,
-    "wof:geomhash":"989f7b301477fc9545bd962c2cf36c25",
+    "wof:geomhash":"4487f54eed71765aefa7052473f55098",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108784807,
-    "wof:lastmodified":1690938918,
+    "wof:lastmodified":1695886562,
     "wof:name":"Guercif",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/110/878/480/9/1108784809.geojson
+++ b/data/110/878/480/9/1108784809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146469,
-    "geom:area_square_m":1496521592.628364,
+    "geom:area_square_m":1496521708.124489,
     "geom:bbox":"-6.311789,34.084662,-5.689263,34.488732",
     "geom:latitude":34.27966,
     "geom:longitude":-6.02615,
@@ -117,9 +117,10 @@
         "hasc:id":"MA.RK.SS",
         "wd:id":"Q3408411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827706,
-    "wof:geomhash":"3899d85f3be90263a20b3729ff7cfdca",
+    "wof:geomhash":"599cfccb4a2762adbb8bb349212888a1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108784809,
-    "wof:lastmodified":1690938918,
+    "wof:lastmodified":1695886563,
     "wof:name":"Sidi Slimane",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/110/878/481/1/1108784811.geojson
+++ b/data/110/878/481/1/1108784811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070945,
-    "geom:area_square_m":727410898.403177,
+    "geom:area_square_m":727410796.009297,
     "geom:bbox":"-6.838778,33.784274,-6.470977,34.161375",
     "geom:latitude":33.98312,
     "geom:longitude":-6.656077,
@@ -132,9 +132,10 @@
         "hasc:id":"MA.RK.SA",
         "wd:id":"Q1611786"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827707,
-    "wof:geomhash":"aeee9c876230cd841893c74d07ef3220",
+    "wof:geomhash":"1156923fdced15d4e9f83f929d887a50",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108784811,
-    "wof:lastmodified":1690938917,
+    "wof:lastmodified":1695886564,
     "wof:name":"Sale",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/110/878/481/3/1108784813.geojson
+++ b/data/110/878/481/3/1108784813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.738189,
-    "geom:area_square_m":7553605682.481945,
+    "geom:area_square_m":7553604855.021846,
     "geom:bbox":"-3.252327,33.347095,-2.274228,34.744525",
     "geom:latitude":34.152245,
     "geom:longitude":-2.815293,
@@ -126,9 +126,10 @@
         "hasc:id":"MA.OF.TA",
         "wd:id":"Q2165392"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827709,
-    "wof:geomhash":"f85efa693d23d5b98a42e47c99b0e89c",
+    "wof:geomhash":"f4ff90a01716f45436115262d51273c5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108784813,
-    "wof:lastmodified":1690938917,
+    "wof:lastmodified":1695886563,
     "wof:name":"Taourirt",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/110/878/481/5/1108784815.geojson
+++ b/data/110/878/481/5/1108784815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.006803,
-    "geom:area_square_m":10903617088.863546,
+    "geom:area_square_m":10903617064.014923,
     "geom:bbox":"-11.123611,28.420388,-8.966105,29.356211",
     "geom:latitude":28.854687,
     "geom:longitude":-10.031478,
@@ -189,9 +189,10 @@
         "hasc:id":"MA.GN.GU",
         "wd:id":"Q923219"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827712,
-    "wof:geomhash":"30119720472aba13dfaa85409a09f6e5",
+    "wof:geomhash":"e46eb941274d3ace9877e50e70a14e48",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -201,7 +202,7 @@
         }
     ],
     "wof:id":1108784815,
-    "wof:lastmodified":1669158473,
+    "wof:lastmodified":1695886561,
     "wof:name":"Guelmim",
     "wof:parent_id":1796661367,
     "wof:placetype":"county",

--- a/data/110/878/481/9/1108784819.geojson
+++ b/data/110/878/481/9/1108784819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.314267,
-    "geom:area_square_m":3273109657.942417,
+    "geom:area_square_m":3273109597.98992,
     "geom:bbox":"-9.056691,32.296704,-8.041112,32.885439",
     "geom:latitude":32.617251,
     "geom:longitude":-8.488129,
@@ -155,9 +155,10 @@
         "hasc:id":"MA.CS.SB",
         "wd:id":"Q3408408"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827713,
-    "wof:geomhash":"dc95b03bc68c37723a4c82cffd0dbe56",
+    "wof:geomhash":"2416769f3d029b40af80f11fc0c6dded",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":1108784819,
-    "wof:lastmodified":1690938917,
+    "wof:lastmodified":1695886559,
     "wof:name":"Sidi Bennour",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/110/878/482/1/1108784821.geojson
+++ b/data/110/878/482/1/1108784821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.282032,
-    "geom:area_square_m":2957578432.21425,
+    "geom:area_square_m":2957578868.216351,
     "geom:bbox":"-8.982153,31.714937,-8.229228,32.330707",
     "geom:latitude":31.996253,
     "geom:longitude":-8.608947,
@@ -114,9 +114,10 @@
         "hasc:id":"MA.MS.YO",
         "wd:id":"Q3408420"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827715,
-    "wof:geomhash":"31714748f9d1070ad8212a85225ea3c2",
+    "wof:geomhash":"556b48d22c7f0153e689702e2c7adf4e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108784821,
-    "wof:lastmodified":1690938912,
+    "wof:lastmodified":1695886562,
     "wof:name":"Youssoufia",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/110/878/482/3/1108784823.geojson
+++ b/data/110/878/482/3/1108784823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.556119,
-    "geom:area_square_m":6079650578.475564,
+    "geom:area_square_m":6079649838.578068,
     "geom:bbox":"-13.174668,27.666572,-11.488631,28.21072",
     "geom:latitude":27.856747,
     "geom:longitude":-12.234142,
@@ -111,9 +111,10 @@
         "hasc:id":"MA.LS.TA",
         "wd:id":"Q15125620"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827715,
-    "wof:geomhash":"fc79662fdbde72e1b7c9d3e05b71af1d",
+    "wof:geomhash":"e65b16534c09dfb3e063ae54440dffd3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108784823,
-    "wof:lastmodified":1690938912,
+    "wof:lastmodified":1695886561,
     "wof:name":"Tarfaya",
     "wof:parent_id":1796661371,
     "wof:placetype":"county",

--- a/data/110/878/482/5/1108784825.geojson
+++ b/data/110/878/482/5/1108784825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.338324,
-    "geom:area_square_m":34718736321.653206,
+    "geom:area_square_m":34718736321.653221,
     "geom:bbox":"-4.01997426879,31.7142835118,-0.996976,33.6970508553",
     "geom:latitude":32.743638,
     "geom:longitude":-2.509071,
@@ -119,9 +119,10 @@
     "wof:concordances":{
         "hasc:id":"MA.OF.FI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827717,
-    "wof:geomhash":"6df320b3bc7dbe2c1bf106c76eea2e63",
+    "wof:geomhash":"c7c32914423ba0b4500911b3412670a6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108784825,
-    "wof:lastmodified":1669159676,
+    "wof:lastmodified":1695886563,
     "wof:name":"Figuig",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/110/878/482/7/1108784827.geojson
+++ b/data/110/878/482/7/1108784827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.91305,
-    "geom:area_square_m":9587928019.185499,
+    "geom:area_square_m":9587928238.201597,
     "geom:bbox":"-7.319478,31.340691,-5.799512,32.401632",
     "geom:latitude":31.870406,
     "geom:longitude":-6.555722,
@@ -135,9 +135,10 @@
         "hasc:id":"MA.BK.AZ",
         "wd:id":"Q793763"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827719,
-    "wof:geomhash":"ced6fb54288ef8c31ef8e6b16fa84ec1",
+    "wof:geomhash":"dd4270bdaae86f59f2819ee088bf51f4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108784827,
-    "wof:lastmodified":1690938912,
+    "wof:lastmodified":1695886559,
     "wof:name":"Azilal",
     "wof:parent_id":1796661357,
     "wof:placetype":"county",

--- a/data/110/878/482/9/1108784829.geojson
+++ b/data/110/878/482/9/1108784829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.249365,
-    "geom:area_square_m":2622687428.032675,
+    "geom:area_square_m":2622686983.8887,
     "geom:bbox":"-8.425557,31.367179,-7.735412,32.081311",
     "geom:latitude":31.726134,
     "geom:longitude":-8.154134,
@@ -121,9 +121,10 @@
         "hasc:id":"MA.MS.MR",
         "wd:id":"Q1673256"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827720,
-    "wof:geomhash":"a945ad15f4b87f47d1f7a281824c11a9",
+    "wof:geomhash":"5722feb895da3697ee28b4f708ab09a1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108784829,
-    "wof:lastmodified":1690938912,
+    "wof:lastmodified":1695886562,
     "wof:name":"Marrakech",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/110/878/483/1/1108784831.geojson
+++ b/data/110/878/483/1/1108784831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.327358,
-    "geom:area_square_m":3504353038.353347,
+    "geom:area_square_m":3504352429.683262,
     "geom:bbox":"-9.763356,29.690117,-8.889376,30.327472",
     "geom:latitude":30.033158,
     "geom:longitude":-9.303461,
@@ -126,9 +126,10 @@
         "hasc:id":"MA.SS.CA",
         "wd:id":"Q2424820"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827722,
-    "wof:geomhash":"ae7f72accfaf6a61e81ce783c63dec1b",
+    "wof:geomhash":"f40eda2ce0b7845150337013ad73124a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108784831,
-    "wof:lastmodified":1690938915,
+    "wof:lastmodified":1695886564,
     "wof:name":"Chtouka Ait Baha",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/110/878/483/3/1108784833.geojson
+++ b/data/110/878/483/3/1108784833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.661996,
-    "geom:area_square_m":6879331739.844169,
+    "geom:area_square_m":6879330982.543153,
     "geom:bbox":"-8.063643,32.325031,-6.847467,33.233907",
     "geom:latitude":32.816188,
     "geom:longitude":-7.409913,
@@ -126,9 +126,10 @@
         "hasc:id":"MA.CS.SE",
         "wd:id":"Q1523840"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827723,
-    "wof:geomhash":"cf9d120fbd4c8a71cfafc220eb227a19",
+    "wof:geomhash":"431169ba6603b31bfbe6dfeab68d72d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108784833,
-    "wof:lastmodified":1690938915,
+    "wof:lastmodified":1695886559,
     "wof:name":"Settat",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/110/878/483/7/1108784837.geojson
+++ b/data/110/878/483/7/1108784837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.174336,
-    "geom:area_square_m":1787102086.858207,
+    "geom:area_square_m":1787102104.444573,
     "geom:bbox":"-5.882881,33.745986,-5.193378,34.253023",
     "geom:latitude":34.002223,
     "geom:longitude":-5.550278,
@@ -129,9 +129,10 @@
         "hasc:id":"MA.FK.ME",
         "wd:id":"Q3408890"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827725,
-    "wof:geomhash":"728503b84b4508d9ec196f4413a1ff2e",
+    "wof:geomhash":"4bb37acb8d6a413b99fe97173c678353",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108784837,
-    "wof:lastmodified":1690938914,
+    "wof:lastmodified":1695886561,
     "wof:name":"Meknes",
     "wof:parent_id":1796661365,
     "wof:placetype":"county",

--- a/data/110/878/483/9/1108784839.geojson
+++ b/data/110/878/483/9/1108784839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.272781,
-    "geom:area_square_m":13443798101.016747,
+    "geom:area_square_m":13443798455.978771,
     "geom:bbox":"-6.446762,30.46338,-4.53055,32.16826",
     "geom:latitude":31.325121,
     "geom:longitude":-5.494566,
@@ -114,9 +114,10 @@
         "hasc:id":"MA.DT.TI",
         "wd:id":"Q3408414"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827729,
-    "wof:geomhash":"a19413e5f94e588e98a5a1363416d693",
+    "wof:geomhash":"56a21edc9024a1d52515630e235fc19d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108784839,
-    "wof:lastmodified":1690938914,
+    "wof:lastmodified":1695886560,
     "wof:name":"Tinghir",
     "wof:parent_id":1796661363,
     "wof:placetype":"county",

--- a/data/110/878/484/1/1108784841.geojson
+++ b/data/110/878/484/1/1108784841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.284174,
-    "geom:area_square_m":3063814097.913237,
+    "geom:area_square_m":3063813269.113661,
     "geom:bbox":"-10.410147,29.029185,-9.159386,29.628643",
     "geom:latitude":29.317192,
     "geom:longitude":-9.842986,
@@ -120,9 +120,10 @@
         "hasc:id":"MA.GN.SI",
         "wd:id":"Q2672941"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827731,
-    "wof:geomhash":"1e4f96cf976dcadcab3a85962cedb684",
+    "wof:geomhash":"ba397c81db27d3ae3996d8644d90f8d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108784841,
-    "wof:lastmodified":1690938915,
+    "wof:lastmodified":1695886561,
     "wof:name":"Sidi Ifni",
     "wof:parent_id":1796661367,
     "wof:placetype":"county",

--- a/data/110/878/484/3/1108784843.geojson
+++ b/data/110/878/484/3/1108784843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.134342,
-    "geom:area_square_m":12033621791.981632,
+    "geom:area_square_m":12033622223.341087,
     "geom:bbox":"-7.751735,30.105449,-6.252499,31.552404",
     "geom:latitude":30.913695,
     "geom:longitude":-7.069497,
@@ -135,9 +135,10 @@
         "hasc:id":"MA.DT.OU",
         "wd:id":"Q1629229"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1481827732,
-    "wof:geomhash":"11d5e9f76daae0fb02ca16f031401858",
+    "wof:geomhash":"a4229ee96b6726c02a343df0c3fd8f75",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108784843,
-    "wof:lastmodified":1690938915,
+    "wof:lastmodified":1695886560,
     "wof:name":"Ouarzazate",
     "wof:parent_id":1796661363,
     "wof:placetype":"county",

--- a/data/179/666/135/7/1796661357.geojson
+++ b/data/179/666/135/7/1796661357.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":2.630031,
+    "geom:area_square_m":27432666857.999485,
     "geom:bbox":"-7.284434,31.372013,-5.250349,33.475425",
     "geom:latitude":32.48073,
     "geom:longitude":-6.298648,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "B\u00e9ni Mellal-Kh\u00e9nifra Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":32.557803,
     "lbl:longitude":-6.318418,
     "mps:latitude":32.557803,
@@ -101,16 +108,30 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_year":"2014-09-01",
+    "statoids:areakm":33208,
+    "statoids:areami":12822,
+    "statoids:capital":"B\u00e9ni Mellal",
+    "statoids:country":"MA",
+    "statoids:date":"2014-09-01",
+    "statoids:hasc":"MA.BK",
+    "statoids:iso":"05",
+    "statoids:name":"B\u00e9ni Mellal-Kh\u00e9nifra",
+    "statoids:population":2520776,
+    "statoids:timezone":"+0~",
+    "statoids:type":"region",
     "wof:belongsto":[
         102191573,
         85632693
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.BK",
         "wd:id":"Q19953016"
     },
     "wof:country":"MA",
-    "wof:geomhash":"ff9aa74eee8b6776d07434467e15dbd5",
+    "wof:geomhash":"80a5202821680f6649d7ce5eb7916e69",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,10 +140,12 @@
         }
     ],
     "wof:id":1796661357,
-    "wof:lastmodified":1690939115,
+    "wof:lastmodified":1694493264,
     "wof:name":"B\u00e9ni Mellal-Kh\u00e9nifra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",
+    "wof:population":2520776,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:superseded_by":[],
     "wof:supersedes":[

--- a/data/179/666/135/7/1796661357.geojson
+++ b/data/179/666/135/7/1796661357.geojson
@@ -128,8 +128,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.BK",
+        "iso:code":"MA-05",
         "wd:id":"Q19953016"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"80a5202821680f6649d7ce5eb7916e69",
     "wof:hierarchy":[
@@ -140,7 +142,7 @@
         }
     ],
     "wof:id":1796661357,
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695885136,
     "wof:name":"B\u00e9ni Mellal-Kh\u00e9nifra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/135/7/1796661357.geojson
+++ b/data/179/666/135/7/1796661357.geojson
@@ -109,7 +109,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
-    "src:population_year":"2014-09-01",
+    "src:population_date":"2014-09-01",
     "statoids:areakm":33208,
     "statoids:areami":12822,
     "statoids:capital":"B\u00e9ni Mellal",
@@ -140,7 +140,7 @@
         }
     ],
     "wof:id":1796661357,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1694639832,
     "wof:name":"B\u00e9ni Mellal-Kh\u00e9nifra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/135/9/1796661359.geojson
+++ b/data/179/666/135/9/1796661359.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":1.944456,
+    "geom:area_square_m":20160104196.321518,
     "geom:bbox":"-9.054533,32.293939,-6.782759,33.834866",
     "geom:latitude":33.018591,
     "geom:longitude":-7.782357,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "Casablanca-Settat Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":33.109524,
     "lbl:longitude":-7.516223,
     "mps:latitude":33.109524,
@@ -92,16 +99,30 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_year":"2014-09-01",
+    "statoids:areakm":20166,
+    "statoids:areami":7786,
+    "statoids:capital":"Casablanca",
+    "statoids:country":"MA",
+    "statoids:date":"2014-09-01",
+    "statoids:hasc":"MA.CS",
+    "statoids:iso":"06",
+    "statoids:name":"Casablanca-Settat",
+    "statoids:population":6861739,
+    "statoids:timezone":"+0~",
+    "statoids:type":"region",
     "wof:belongsto":[
         102191573,
         85632693
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.CS",
         "wd:id":"Q19843788"
     },
     "wof:country":"MA",
-    "wof:geomhash":"1703ca34344ef60fd6c055d3309e0fc0",
+    "wof:geomhash":"942aa87164e5080f95ad7311fc50ac6e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,10 +131,12 @@
         }
     ],
     "wof:id":1796661359,
-    "wof:lastmodified":1690939115,
+    "wof:lastmodified":1694493264,
     "wof:name":"Casablanca-Settat",
     "wof:parent_id":85632693,
     "wof:placetype":"region",
+    "wof:population":6861739,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:superseded_by":[],
     "wof:supersedes":[

--- a/data/179/666/135/9/1796661359.geojson
+++ b/data/179/666/135/9/1796661359.geojson
@@ -119,8 +119,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.CS",
+        "iso:code":"MA-06",
         "wd:id":"Q19843788"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"942aa87164e5080f95ad7311fc50ac6e",
     "wof:hierarchy":[
@@ -131,7 +133,7 @@
         }
     ],
     "wof:id":1796661359,
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695885136,
     "wof:name":"Casablanca-Settat",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/135/9/1796661359.geojson
+++ b/data/179/666/135/9/1796661359.geojson
@@ -100,7 +100,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
-    "src:population_year":"2014-09-01",
+    "src:population_date":"2014-09-01",
     "statoids:areakm":20166,
     "statoids:areami":7786,
     "statoids:capital":"Casablanca",
@@ -131,7 +131,7 @@
         }
     ],
     "wof:id":1796661359,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1694639832,
     "wof:name":"Casablanca-Settat",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/1/1796661361.geojson
+++ b/data/179/666/136/1/1796661361.geojson
@@ -122,8 +122,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.OL",
+        "iso:code":"MA-12",
         "wd:id":"Q21235104"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"85be0f5701d7c4848ab13d45788621d0",
     "wof:hierarchy":[
@@ -134,7 +136,7 @@
         }
     ],
     "wof:id":1796661361,
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695885136,
     "wof:name":"Dakhla-Oued Ed-Dahab",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/1/1796661361.geojson
+++ b/data/179/666/136/1/1796661361.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":6.649102,
+    "geom:area_square_m":75700519844.188843,
     "geom:bbox":"-17.013743,21.419971,-12.94688,24.591541",
     "geom:latitude":22.950126,
     "geom:longitude":-15.134951,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "Dakhla-Oued Ed-Dahab Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":22.877092,
     "lbl:longitude":-15.165652,
     "mps:latitude":22.877092,
@@ -95,16 +102,30 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_year":"2014-09-01",
+    "statoids:areakm":142865,
+    "statoids:areami":55160,
+    "statoids:capital":"Oued Ed-Dahab",
+    "statoids:country":"MA",
+    "statoids:date":"2014-09-01",
+    "statoids:hasc":"MA.OL",
+    "statoids:iso":"12",
+    "statoids:name":"Dakhla-Oued Ed-Dahab",
+    "statoids:population":142955,
+    "statoids:timezone":"+0~",
+    "statoids:type":"region",
     "wof:belongsto":[
         102191573,
         85632693
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.OL",
         "wd:id":"Q21235104"
     },
     "wof:country":"MA",
-    "wof:geomhash":"6a486adc63d2d986e84b007ca566433a",
+    "wof:geomhash":"85be0f5701d7c4848ab13d45788621d0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,10 +134,12 @@
         }
     ],
     "wof:id":1796661361,
-    "wof:lastmodified":1690939115,
+    "wof:lastmodified":1694493264,
     "wof:name":"Dakhla-Oued Ed-Dahab",
     "wof:parent_id":85632693,
     "wof:placetype":"region",
+    "wof:population":142955,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/179/666/136/1/1796661361.geojson
+++ b/data/179/666/136/1/1796661361.geojson
@@ -103,7 +103,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
-    "src:population_year":"2014-09-01",
+    "src:population_date":"2014-09-01",
     "statoids:areakm":142865,
     "statoids:areami":55160,
     "statoids:capital":"Oued Ed-Dahab",
@@ -134,7 +134,7 @@
         }
     ],
     "wof:id":1796661361,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1694639832,
     "wof:name":"Dakhla-Oued Ed-Dahab",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/3/1796661363.geojson
+++ b/data/179/666/136/3/1796661363.geojson
@@ -91,7 +91,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
-    "src:population_year":"2014-09-01",
+    "src:population_date":"2014-09-01",
     "statoids:areakm":105383,
     "statoids:areami":40689,
     "statoids:capital":"Errachidia",
@@ -122,7 +122,7 @@
         }
     ],
     "wof:id":1796661363,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1694639832,
     "wof:name":"Dr\u00e2a-Tafilalet",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/3/1796661363.geojson
+++ b/data/179/666/136/3/1796661363.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":8.178222,
+    "geom:area_square_m":86480444699.783142,
     "geom:bbox":"-7.750779,29.495261,-3.152257,33.092265",
     "geom:latitude":31.211578,
     "geom:longitude":-5.358971,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "Dr\u00e2a-Tafilalet Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":31.10931,
     "lbl:longitude":-5.202168,
     "mps:latitude":31.10931,
@@ -83,16 +90,30 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_year":"2014-09-01",
+    "statoids:areakm":105383,
+    "statoids:areami":40689,
+    "statoids:capital":"Errachidia",
+    "statoids:country":"MA",
+    "statoids:date":"2014-09-01",
+    "statoids:hasc":"MA.DT",
+    "statoids:iso":"08",
+    "statoids:name":"Dr\u00e2a-Tafilalet",
+    "statoids:population":1635008,
+    "statoids:timezone":"+0~",
+    "statoids:type":"region",
     "wof:belongsto":[
         102191573,
         85632693
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.DT",
         "wd:id":"Q19950954"
     },
     "wof:country":"MA",
-    "wof:geomhash":"218fca706033d6dd6222cef37cf2ef8d",
+    "wof:geomhash":"810854a94210b59502818aa7569e90f6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,10 +122,12 @@
         }
     ],
     "wof:id":1796661363,
-    "wof:lastmodified":1690939116,
+    "wof:lastmodified":1694493264,
     "wof:name":"Dr\u00e2a-Tafilalet",
     "wof:parent_id":85632693,
     "wof:placetype":"region",
+    "wof:population":1635008,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:superseded_by":[],
     "wof:supersedes":[

--- a/data/179/666/136/3/1796661363.geojson
+++ b/data/179/666/136/3/1796661363.geojson
@@ -110,8 +110,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.DT",
+        "iso:code":"MA-08",
         "wd:id":"Q19950954"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"810854a94210b59502818aa7569e90f6",
     "wof:hierarchy":[
@@ -122,7 +124,7 @@
         }
     ],
     "wof:id":1796661363,
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695885136,
     "wof:name":"Dr\u00e2a-Tafilalet",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/5/1796661365.geojson
+++ b/data/179/666/136/5/1796661365.geojson
@@ -122,8 +122,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.FK",
+        "iso:code":"MA-03",
         "wd:id":"Q19951027"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"3931242f41832975f7ccbbf2c08e370d",
     "wof:hierarchy":[
@@ -134,7 +136,7 @@
         }
     ],
     "wof:id":1796661365,
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885136,
     "wof:name":"F\u00e8s-Mekn\u00e8s",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/5/1796661365.geojson
+++ b/data/179/666/136/5/1796661365.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":3.796911,
+    "geom:area_square_m":39032382483.438019,
     "geom:bbox":"-5.885062,32.613152,-2.926121,34.911447",
     "geom:latitude":33.756894,
     "geom:longitude":-4.488364,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "F\u00e8s-Mekn\u00e8s Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":33.912343,
     "lbl:longitude":-4.757109,
     "mps:latitude":33.912343,
@@ -95,16 +102,30 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_year":"2014-09-01",
+    "statoids:areakm":47705,
+    "statoids:areami":18419,
+    "statoids:capital":"F\u00e8s",
+    "statoids:country":"MA",
+    "statoids:date":"2014-09-01",
+    "statoids:hasc":"MA.FK",
+    "statoids:iso":"03",
+    "statoids:name":"F\u00e8s-Mekn\u00e8s",
+    "statoids:population":4236892,
+    "statoids:timezone":"+0~",
+    "statoids:type":"region",
     "wof:belongsto":[
         102191573,
         85632693
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.FK",
         "wd:id":"Q19951027"
     },
     "wof:country":"MA",
-    "wof:geomhash":"41ba25cd537b3befe1b397e2de0b0798",
+    "wof:geomhash":"3931242f41832975f7ccbbf2c08e370d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,10 +134,12 @@
         }
     ],
     "wof:id":1796661365,
-    "wof:lastmodified":1690939116,
+    "wof:lastmodified":1694493264,
     "wof:name":"F\u00e8s-Mekn\u00e8s",
     "wof:parent_id":85632693,
     "wof:placetype":"region",
+    "wof:population":4236892,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:superseded_by":[],
     "wof:supersedes":[

--- a/data/179/666/136/5/1796661365.geojson
+++ b/data/179/666/136/5/1796661365.geojson
@@ -103,7 +103,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
-    "src:population_year":"2014-09-01",
+    "src:population_date":"2014-09-01",
     "statoids:areakm":47705,
     "statoids:areami":18419,
     "statoids:capital":"F\u00e8s",
@@ -134,7 +134,7 @@
         }
     ],
     "wof:id":1796661365,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1694639833,
     "wof:name":"F\u00e8s-Mekn\u00e8s",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/7/1796661367.geojson
+++ b/data/179/666/136/7/1796661367.geojson
@@ -112,7 +112,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
-    "src:population_year":"2014-09-01",
+    "src:population_date":"2014-09-01",
     "statoids:areakm":64473,
     "statoids:areami":24893,
     "statoids:capital":"Guelmim",
@@ -143,7 +143,7 @@
         }
     ],
     "wof:id":1796661367,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1694639833,
     "wof:name":"Guelmim-Oued Noun",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/136/7/1796661367.geojson
+++ b/data/179/666/136/7/1796661367.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":4.057016,
+    "geom:area_square_m":44143364198.379845,
     "geom:bbox":"-11.782298,27.147639,-8.682385,29.626566",
     "geom:latitude":28.359108,
     "geom:longitude":-9.972438,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "Guelmim-Oued Noun Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":28.472321,
     "lbl:longitude":-9.866709,
     "mps:latitude":28.472321,
@@ -104,16 +111,30 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_year":"2014-09-01",
+    "statoids:areakm":64473,
+    "statoids:areami":24893,
+    "statoids:capital":"Guelmim",
+    "statoids:country":"MA",
+    "statoids:date":"2014-09-01",
+    "statoids:hasc":"MA.GN",
+    "statoids:iso":"10",
+    "statoids:name":"Guelmim-Oued Noun",
+    "statoids:population":433757,
+    "statoids:timezone":"+0~",
+    "statoids:type":"region",
     "wof:belongsto":[
         102191573,
         85632693
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.GN",
         "wd:id":"Q19951051"
     },
     "wof:country":"MA",
-    "wof:geomhash":"db1d25fe12a230948cf10a4567f187d4",
+    "wof:geomhash":"a59df4be3e8bea59dd2ffd886ccbd574",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,10 +143,12 @@
         }
     ],
     "wof:id":1796661367,
-    "wof:lastmodified":1690939115,
+    "wof:lastmodified":1694493264,
     "wof:name":"Guelmim-Oued Noun",
     "wof:parent_id":85632693,
     "wof:placetype":"region",
+    "wof:population":433757,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:superseded_by":[],
     "wof:supersedes":[

--- a/data/179/666/136/7/1796661367.geojson
+++ b/data/179/666/136/7/1796661367.geojson
@@ -131,8 +131,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.GN",
+        "iso:code":"MA-10",
         "wd:id":"Q19951051"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"a59df4be3e8bea59dd2ffd886ccbd574",
     "wof:hierarchy":[
@@ -143,7 +145,7 @@
         }
     ],
     "wof:id":1796661367,
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885136,
     "wof:name":"Guelmim-Oued Noun",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/1/1796661371.geojson
+++ b/data/179/666/137/1/1796661371.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":9.683771,
+    "geom:area_square_m":107295372311.389557,
     "geom:bbox":"-15.012236,24.393989,-8.756698,28.210141",
     "geom:latitude":26.337779,
     "geom:longitude":-12.578436,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "La\u00e2youne-Sakia El Hamra Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":25.623963,
     "lbl:longitude":-13.311566,
     "mps:latitude":25.623963,
@@ -101,16 +108,30 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_year":"2014-09-01",
+    "statoids:areakm":121219,
+    "statoids:areami":46803,
+    "statoids:capital":"La\u00e2youne",
+    "statoids:country":"MA",
+    "statoids:date":"2014-09-01",
+    "statoids:hasc":"MA.LS",
+    "statoids:iso":"11",
+    "statoids:name":"La\u00e2youne-Sakia al Hamra",
+    "statoids:population":367758,
+    "statoids:timezone":"+0",
+    "statoids:type":"region",
     "wof:belongsto":[
         102191573,
         85632693
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.LS",
         "wd:id":"Q19951088"
     },
     "wof:country":"MA",
-    "wof:geomhash":"47399446aa1ae388d319e196fd5e648d",
+    "wof:geomhash":"1d583a9c336e4a7b9281b02876e39591",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,10 +140,12 @@
         }
     ],
     "wof:id":1796661371,
-    "wof:lastmodified":1690939117,
+    "wof:lastmodified":1694493264,
     "wof:name":"La\u00e2youne-Sakia El Hamra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",
+    "wof:population":367758,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:superseded_by":[],
     "wof:supersedes":[

--- a/data/179/666/137/1/1796661371.geojson
+++ b/data/179/666/137/1/1796661371.geojson
@@ -128,8 +128,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.LS",
+        "iso:code":"MA-11",
         "wd:id":"Q19951088"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"1d583a9c336e4a7b9281b02876e39591",
     "wof:hierarchy":[
@@ -140,7 +142,7 @@
         }
     ],
     "wof:id":1796661371,
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885136,
     "wof:name":"La\u00e2youne-Sakia El Hamra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/1/1796661371.geojson
+++ b/data/179/666/137/1/1796661371.geojson
@@ -109,7 +109,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
-    "src:population_year":"2014-09-01",
+    "src:population_date":"2014-09-01",
     "statoids:areakm":121219,
     "statoids:areami":46803,
     "statoids:capital":"La\u00e2youne",
@@ -140,7 +140,7 @@
         }
     ],
     "wof:id":1796661371,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1694639833,
     "wof:name":"La\u00e2youne-Sakia El Hamra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/3/1796661373.geojson
+++ b/data/179/666/137/3/1796661373.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":3.708519,
+    "geom:area_square_m":39004212218.885086,
     "geom:bbox":"-9.847524,30.829359,-7.027602,32.834043",
     "geom:latitude":31.723164,
     "geom:longitude":-8.457831,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "Marrakesh-Safi Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":31.612743,
     "lbl:longitude":-8.484438,
     "mps:latitude":31.612743,
@@ -101,16 +108,30 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_year":"2014-09-01",
+    "statoids:areakm":38445,
+    "statoids:areami":14844,
+    "statoids:capital":"Marrakech",
+    "statoids:country":"MA",
+    "statoids:date":"2014-09-01",
+    "statoids:hasc":"MA.MS",
+    "statoids:iso":"07",
+    "statoids:name":"Marrakech-Safi",
+    "statoids:population":4520569,
+    "statoids:timezone":"+0~",
+    "statoids:type":"region",
     "wof:belongsto":[
         102191573,
         85632693
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.MS",
         "wd:id":"Q19951125"
     },
     "wof:country":"MA",
-    "wof:geomhash":"6e1e1e3c3da9d594df54069ad7da41a8",
+    "wof:geomhash":"c5b8fa743bbdb9dd87c735af9501444f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,10 +140,12 @@
         }
     ],
     "wof:id":1796661373,
-    "wof:lastmodified":1690939117,
+    "wof:lastmodified":1694493264,
     "wof:name":"Marrakesh-Safi",
     "wof:parent_id":85632693,
     "wof:placetype":"region",
+    "wof:population":4520569,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:superseded_by":[],
     "wof:supersedes":[

--- a/data/179/666/137/3/1796661373.geojson
+++ b/data/179/666/137/3/1796661373.geojson
@@ -128,8 +128,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.MS",
+        "iso:code":"MA-07",
         "wd:id":"Q19951125"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"c5b8fa743bbdb9dd87c735af9501444f",
     "wof:hierarchy":[
@@ -140,7 +142,7 @@
         }
     ],
     "wof:id":1796661373,
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885136,
     "wof:name":"Marrakesh-Safi",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/3/1796661373.geojson
+++ b/data/179/666/137/3/1796661373.geojson
@@ -109,7 +109,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
-    "src:population_year":"2014-09-01",
+    "src:population_date":"2014-09-01",
     "statoids:areakm":38445,
     "statoids:areami":14844,
     "statoids:capital":"Marrakech",
@@ -140,7 +140,7 @@
         }
     ],
     "wof:id":1796661373,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1694639833,
     "wof:name":"Marrakesh-Safi",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/5/1796661375.geojson
+++ b/data/179/666/137/5/1796661375.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":6.340493,
+    "geom:area_square_m":65351542014.016273,
     "geom:bbox":"-4.083363,31.732546,-1.031999,35.446438",
     "geom:latitude":33.523175,
     "geom:longitude":-2.665822,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "Oriental Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":33.630785,
     "lbl:longitude":-2.38982,
     "mps:latitude":33.630785,
@@ -110,16 +117,30 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_year":"2014-09-01",
+    "statoids:areakm":82820,
+    "statoids:areami":31977,
+    "statoids:capital":"Oujda",
+    "statoids:country":"MA",
+    "statoids:date":"2014-09-01",
+    "statoids:hasc":"MA.OF",
+    "statoids:iso":"02",
+    "statoids:name":"L'oriental",
+    "statoids:population":2314346,
+    "statoids:timezone":"+0~",
+    "statoids:type":"region",
     "wof:belongsto":[
         102191573,
         85632693
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.OF",
         "wd:id":"Q23048167"
     },
     "wof:country":"MA",
-    "wof:geomhash":"5d125438286230051499626ae6657b26",
+    "wof:geomhash":"289a99257c76b15ff4f1d7a22b86200a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,10 +149,12 @@
         }
     ],
     "wof:id":1796661375,
-    "wof:lastmodified":1690939118,
+    "wof:lastmodified":1694493264,
     "wof:name":"Oriental",
     "wof:parent_id":85632693,
     "wof:placetype":"region",
+    "wof:population":2314346,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:superseded_by":[],
     "wof:supersedes":[

--- a/data/179/666/137/5/1796661375.geojson
+++ b/data/179/666/137/5/1796661375.geojson
@@ -118,7 +118,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
-    "src:population_year":"2014-09-01",
+    "src:population_date":"2014-09-01",
     "statoids:areakm":82820,
     "statoids:areami":31977,
     "statoids:capital":"Oujda",
@@ -149,7 +149,7 @@
         }
     ],
     "wof:id":1796661375,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1694639833,
     "wof:name":"Oriental",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/5/1796661375.geojson
+++ b/data/179/666/137/5/1796661375.geojson
@@ -137,8 +137,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.OF",
+        "iso:code":"MA-02",
         "wd:id":"Q23048167"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"289a99257c76b15ff4f1d7a22b86200a",
     "wof:hierarchy":[
@@ -149,7 +151,7 @@
         }
     ],
     "wof:id":1796661375,
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885136,
     "wof:name":"Oriental",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/7/1796661377.geojson
+++ b/data/179/666/137/7/1796661377.geojson
@@ -97,7 +97,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
-    "src:population_year":"2014-09-01",
+    "src:population_date":"2014-09-01",
     "statoids:areakm":18385,
     "statoids:areami":7098,
     "statoids:capital":"Rabat",
@@ -128,7 +128,7 @@
         }
     ],
     "wof:id":1796661377,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1694639833,
     "wof:name":"Rabat-Sal\u00e9-K\u00e9nitra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/7/1796661377.geojson
+++ b/data/179/666/137/7/1796661377.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":1.704299,
+    "geom:area_square_m":17455003404.465809,
     "geom:bbox":"-7.117014,33.187949,-5.304844,35.010163",
     "geom:latitude":34.074072,
     "geom:longitude":-6.206887,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "Rabat-Sal\u00e9-K\u00e9nitra Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":33.925674,
     "lbl:longitude":-6.296147,
     "mps:latitude":33.925674,
@@ -89,16 +96,30 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_year":"2014-09-01",
+    "statoids:areakm":18385,
+    "statoids:areami":7098,
+    "statoids:capital":"Rabat",
+    "statoids:country":"MA",
+    "statoids:date":"2014-09-01",
+    "statoids:hasc":"MA.RK",
+    "statoids:iso":"04",
+    "statoids:name":"Rabat-Sal\u00e9-K\u00e9nitra",
+    "statoids:population":4580866,
+    "statoids:timezone":"+0~",
+    "statoids:type":"region",
     "wof:belongsto":[
         102191573,
         85632693
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.RK",
         "wd:id":"Q19951239"
     },
     "wof:country":"MA",
-    "wof:geomhash":"dd8100373f9faff314904c9b6cdc2a39",
+    "wof:geomhash":"b15cda19f2701221d5bba1f7eb667761",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -107,10 +128,12 @@
         }
     ],
     "wof:id":1796661377,
-    "wof:lastmodified":1690939117,
+    "wof:lastmodified":1694493264,
     "wof:name":"Rabat-Sal\u00e9-K\u00e9nitra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",
+    "wof:population":4580866,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:superseded_by":[],
     "wof:supersedes":[

--- a/data/179/666/137/7/1796661377.geojson
+++ b/data/179/666/137/7/1796661377.geojson
@@ -116,8 +116,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.RK",
+        "iso:code":"MA-04",
         "wd:id":"Q19951239"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"b15cda19f2701221d5bba1f7eb667761",
     "wof:hierarchy":[
@@ -128,7 +130,7 @@
         }
     ],
     "wof:id":1796661377,
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885136,
     "wof:name":"Rabat-Sal\u00e9-K\u00e9nitra",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/9/1796661379.geojson
+++ b/data/179/666/137/9/1796661379.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":5.050346,
+    "geom:area_square_m":54112685027.212311,
     "geom:bbox":"-10.019958,28.3502,-6.34391,31.17073",
     "geom:latitude":29.939387,
     "geom:longitude":-8.341756,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "Souss-Massa Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":29.944537,
     "lbl:longitude":-8.467293,
     "mps:latitude":29.944537,
@@ -95,16 +102,30 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"statoids",
+    "src:population_year":"2014-09-01",
+    "statoids:areakm":51642,
+    "statoids:areami":19939,
+    "statoids:capital":"Agadir-Ida-Ou-Tanane",
+    "statoids:country":"MA",
+    "statoids:date":"2014-09-01",
+    "statoids:hasc":"MA.SS",
+    "statoids:iso":"09",
+    "statoids:name":"Souss-Massa",
+    "statoids:population":2676847,
+    "statoids:timezone":"+0",
+    "statoids:type":"region",
     "wof:belongsto":[
         102191573,
         85632693
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.SS",
         "wd:id":"Q20652586"
     },
     "wof:country":"MA",
-    "wof:geomhash":"4ebce0e926367659becee84faf4a55bc",
+    "wof:geomhash":"17c36835c78162c3361dc0cc38706a1e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,10 +134,12 @@
         }
     ],
     "wof:id":1796661379,
-    "wof:lastmodified":1690939117,
+    "wof:lastmodified":1694493264,
     "wof:name":"Souss-Massa",
     "wof:parent_id":85632693,
     "wof:placetype":"region",
+    "wof:population":2676847,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:superseded_by":[],
     "wof:supersedes":[

--- a/data/179/666/137/9/1796661379.geojson
+++ b/data/179/666/137/9/1796661379.geojson
@@ -122,8 +122,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.SS",
+        "iso:code":"MA-09",
         "wd:id":"Q20652586"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"17c36835c78162c3361dc0cc38706a1e",
     "wof:hierarchy":[
@@ -134,7 +136,7 @@
         }
     ],
     "wof:id":1796661379,
-    "wof:lastmodified":1694639833,
+    "wof:lastmodified":1695885136,
     "wof:name":"Souss-Massa",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/137/9/1796661379.geojson
+++ b/data/179/666/137/9/1796661379.geojson
@@ -103,7 +103,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
-    "src:population_year":"2014-09-01",
+    "src:population_date":"2014-09-01",
     "statoids:areakm":51642,
     "statoids:areami":19939,
     "statoids:capital":"Agadir-Ida-Ou-Tanane",
@@ -134,7 +134,7 @@
         }
     ],
     "wof:id":1796661379,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1694639833,
     "wof:name":"Souss-Massa",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/138/1/1796661381.geojson
+++ b/data/179/666/138/1/1796661381.geojson
@@ -110,8 +110,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"MA.TC\t",
+        "iso:code":"MA-01",
         "wd:id":"Q19951300"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"3e650f1c4ea653e583b7f32ef94d0eb1",
     "wof:hierarchy":[
@@ -122,7 +124,7 @@
         }
     ],
     "wof:id":1796661381,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1695885136,
     "wof:name":"Tanger-Tetouan-Al Hoceima",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/179/666/138/1/1796661381.geojson
+++ b/data/179/666/138/1/1796661381.geojson
@@ -7,10 +7,17 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2022-03-05",
     "geom:area":1.612336,
+    "geom:area_square_m":16301280911.654976,
     "geom:bbox":"-6.249209,34.508151,-3.791858,35.926519",
     "geom:latitude":35.147763,
     "geom:longitude":-5.177171,
     "iso:country":"MA",
+    "label:eng_x_preferred_longname":[
+        "Tanger-Tetouan-Al Hoceima Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
+    ],
     "lbl:latitude":35.112054,
     "lbl:longitude":-5.399798,
     "mps:latitude":35.112054,
@@ -102,10 +109,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "hasc:id":"MA.TC\t",
         "wd:id":"Q19951300"
     },
     "wof:country":"MA",
-    "wof:geomhash":"b6e27702a2f259ef2cde7b8ed61e95b3",
+    "wof:geomhash":"3e650f1c4ea653e583b7f32ef94d0eb1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +122,7 @@
         }
     ],
     "wof:id":1796661381,
-    "wof:lastmodified":1690939116,
+    "wof:lastmodified":1694493264,
     "wof:name":"Tanger-Tetouan-Al Hoceima",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/856/326/93/85632693.geojson
+++ b/data/856/326/93/85632693.geojson
@@ -1207,7 +1207,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"naturalearth",
-    "src:population_year":"2019",
+    "src:population_date":"2019",
     "statoids:dial":"212",
     "statoids:ds":"MA",
     "statoids:fifa":"MAR",
@@ -1285,7 +1285,7 @@
         "fra",
         "tzm"
     ],
-    "wof:lastmodified":1694492219,
+    "wof:lastmodified":1694639673,
     "wof:name":"Morocco",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/326/93/85632693.geojson
+++ b/data/856/326/93/85632693.geojson
@@ -1245,6 +1245,7 @@
         "hasc:id":"MA",
         "icao:code":"CN",
         "ioc:id":"MAR",
+        "iso:code":"MA",
         "itu:id":"MRC",
         "loc:id":"n79069715",
         "m49:code":"504",
@@ -1259,6 +1260,7 @@
         "wk:page":"Morocco",
         "wmo:id":"MC"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:country_alpha3":"MAR",
     "wof:geom_alt":[
@@ -1285,7 +1287,7 @@
         "fra",
         "tzm"
     ],
-    "wof:lastmodified":1694639673,
+    "wof:lastmodified":1695881332,
     "wof:name":"Morocco",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/326/93/85632693.geojson
+++ b/data/856/326/93/85632693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":55.467583,
-    "geom:area_square_m":592469513863.421387,
+    "geom:area_square_m":593659766927.613892,
     "geom:bbox":"-17.021574,21.417183,-0.996976,35.922717",
     "geom:latitude":29.843508,
     "geom:longitude":-8.389315,
@@ -14,6 +14,9 @@
     "iso:country":"MA",
     "itu:country_code":[
         "212"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "country"
     ],
     "lbl:latitude":31.657061,
     "lbl:longitude":-7.182618,
@@ -1203,7 +1206,8 @@
         "whosonfirst"
     ],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"wk",
+    "src:population":"naturalearth",
+    "src:population_year":"2019",
     "statoids:dial":"212",
     "statoids:ds":"MA",
     "statoids:fifa":"MAR",
@@ -1263,7 +1267,7 @@
         "naturalearth",
         "whosonfirst-interior"
     ],
-    "wof:geomhash":"fd23b6687346838cdd2bff761a8ba0a7",
+    "wof:geomhash":"a6809b2a07043809569aebd5bca6d402",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -1281,12 +1285,12 @@
         "fra",
         "tzm"
     ],
-    "wof:lastmodified":1690938901,
+    "wof:lastmodified":1694492219,
     "wof:name":"Morocco",
     "wof:parent_id":102191573,
     "wof:placetype":"country",
-    "wof:population":33008150,
-    "wof:population_rank":15,
+    "wof:population":36471769,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ma",
     "wof:shortcode":"MA",
     "wof:superseded_by":[],

--- a/data/856/739/51/85673951.geojson
+++ b/data/856/739/51/85673951.geojson
@@ -5,13 +5,16 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.649102,
-    "geom:area_square_m":75700518910.072922,
+    "geom:area_square_m":75700519844.188736,
     "geom:bbox":"-17.013743,21.419971,-12.94688,24.591541",
     "geom:latitude":22.950126,
     "geom:longitude":-15.134951,
     "iso:country":"MA",
     "label:eng_x_preferred_longname":[
         "Oued Ed-Dahab Region"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "region"
     ],
     "lbl:latitude":22.877092,
     "lbl:longitude":-15.165652,
@@ -118,7 +121,7 @@
         "hasc:id":"MA.OD"
     },
     "wof:country":"MA",
-    "wof:geomhash":"58c38cfe3ce4a964544df8361a3d9e1f",
+    "wof:geomhash":"4ab2ae329b2f8a7528a183993e5efd75",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -137,7 +140,7 @@
         "fra",
         "tzm"
     ],
-    "wof:lastmodified":1614895347,
+    "wof:lastmodified":1694493174,
     "wof:name":"Oued Ed-Dahab",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/856/739/51/85673951.geojson
+++ b/data/856/739/51/85673951.geojson
@@ -118,8 +118,10 @@
         "fips:code":"WI00",
         "gn:id":7627603,
         "gp:id":24549935,
-        "hasc:id":"MA.OD"
+        "hasc:id":"MA.OD",
+        "iso:code":"MA-12"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MA",
     "wof:geomhash":"4ab2ae329b2f8a7528a183993e5efd75",
     "wof:hierarchy":[
@@ -140,7 +142,7 @@
         "fra",
         "tzm"
     ],
-    "wof:lastmodified":1694493174,
+    "wof:lastmodified":1695884535,
     "wof:name":"Oued Ed-Dahab",
     "wof:parent_id":85632693,
     "wof:placetype":"region",

--- a/data/890/418/103/890418103.geojson
+++ b/data/890/418/103/890418103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.54743,
-    "geom:area_square_m":5580446852.450783,
+    "geom:area_square_m":5580446827.400876,
     "geom:bbox":"-5.525544,34.039401,-4.087644,34.839491",
     "geom:latitude":34.471699,
     "geom:longitude":-4.795522,
@@ -137,12 +137,13 @@
         "wd:id":"Q1969671",
         "wk:page":"Taounate"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051234,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f96cb4ab2ba8a06cbea4a7cb1018888c",
+    "wof:geomhash":"8049ebca0fc909da14cc5854fc1ab302",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":890418103,
-    "wof:lastmodified":1690939097,
+    "wof:lastmodified":1695886564,
     "wof:name":"Taounate",
     "wof:parent_id":1796661365,
     "wof:placetype":"county",

--- a/data/890/418/107/890418107.geojson
+++ b/data/890/418/107/890418107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.011177,
-    "geom:area_square_m":11033211880.4207,
+    "geom:area_square_m":11033212266.909054,
     "geom:bbox":"-11.781929,27.667819,-10.21788,28.677666",
     "geom:latitude":28.063837,
     "geom:longitude":-10.984357,
@@ -138,12 +138,13 @@
         "wd:id":"Q972535",
         "wk:page":"Tan-Tan"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051234,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"85d108862dd27449b0e641e8d95f640f",
+    "wof:geomhash":"2170eab8f358a403e3f86ffbfc1c988d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":890418107,
-    "wof:lastmodified":1690939097,
+    "wof:lastmodified":1695886565,
     "wof:name":"Tan-Tan",
     "wof:parent_id":1796661367,
     "wof:placetype":"county",

--- a/data/890/421/483/890421483.geojson
+++ b/data/890/421/483/890421483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.189063,
-    "geom:area_square_m":1904265272.653332,
+    "geom:area_square_m":1904265681.235758,
     "geom:bbox":"-5.831048,35.208222,-5.084583,35.697901",
     "geom:latitude":35.456765,
     "geom:longitude":-5.432057,
@@ -144,12 +144,13 @@
         "wd:id":"Q1257443",
         "wk:page":"T\u00e9touan"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051394,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"818f62abb959461ff5fe082af09052ae",
+    "wof:geomhash":"f5307b6a35522268752271cb532e6466",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":890421483,
-    "wof:lastmodified":1690939046,
+    "wof:lastmodified":1695886565,
     "wof:name":"Tetouan",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/890/422/513/890422513.geojson
+++ b/data/890/422/513/890422513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.271564,
-    "geom:area_square_m":2744811581.661971,
+    "geom:area_square_m":2744811537.298752,
     "geom:bbox":"-6.247182,34.922957,-5.461153,35.469656",
     "geom:latitude":35.173454,
     "geom:longitude":-5.832166,
@@ -152,12 +152,13 @@
         "wd:id":"Q1759567",
         "wk:page":"Larache"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051449,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de48e07d5f8cedd7b0d4649300b49598",
+    "wof:geomhash":"959e5faac1f725ee3990f23519495b8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":890422513,
-    "wof:lastmodified":1690938971,
+    "wof:lastmodified":1695886565,
     "wof:name":"Larache",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/890/422/519/890422519.geojson
+++ b/data/890/422/519/890422519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.426528,
-    "geom:area_square_m":4427661867.824786,
+    "geom:area_square_m":4427661870.6833,
     "geom:bbox":"-7.052494,32.618717,-6.047095,33.235229",
     "geom:latitude":32.91132,
     "geom:longitude":-6.572717,
@@ -138,12 +138,13 @@
         "wd:id":"Q1740686",
         "wk:page":"Khouribga Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051450,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"789cce15a005ad4972c775a53652b1ad",
+    "wof:geomhash":"8e9c4c6292df20df605fbfb46ebed1e1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":890422519,
-    "wof:lastmodified":1690938969,
+    "wof:lastmodified":1695886565,
     "wof:name":"Khouribga",
     "wof:parent_id":1796661357,
     "wof:placetype":"county",

--- a/data/890/422/523/890422523.geojson
+++ b/data/890/422/523/890422523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.604571,
-    "geom:area_square_m":17492319434.791355,
+    "geom:area_square_m":17492320176.000946,
     "geom:bbox":"-10.737826,27.667028,-8.666665,28.812144",
     "geom:latitude":28.158801,
     "geom:longitude":-9.528085,
@@ -142,12 +142,13 @@
         "qs_pg:id":575132,
         "wd:id":"Q180994"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051450,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fff50b05b288fec94fea987e9db29694",
+    "wof:geomhash":"47123c4a9d212e6fc60e2009244e09f7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":890422523,
-    "wof:lastmodified":1690938971,
+    "wof:lastmodified":1695886565,
     "wof:name":"Assa-Zag",
     "wof:parent_id":1796661367,
     "wof:placetype":"county",

--- a/data/890/424/145/890424145.geojson
+++ b/data/890/424/145/890424145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050456,
-    "geom:area_square_m":520710312.533692,
+    "geom:area_square_m":520710361.566187,
     "geom:bbox":"-7.879659,33.271233,-7.532274,33.567629",
     "geom:latitude":33.424441,
     "geom:longitude":-7.678409,
@@ -140,12 +140,13 @@
         "wd:id":"Q516261",
         "wk:page":"Nouaceur"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051531,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b6006cec00fd5e1824e8921d374a4ed9",
+    "wof:geomhash":"5d340d567df07e99639df99d21fba95a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":890424145,
-    "wof:lastmodified":1690938988,
+    "wof:lastmodified":1695886565,
     "wof:name":"Nouaceur",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/424/147/890424147.geojson
+++ b/data/890/424/147/890424147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02792,
-    "geom:area_square_m":287477535.272845,
+    "geom:area_square_m":287477736.819273,
     "geom:bbox":"-7.501966,33.499818,-7.278756,33.732132",
     "geom:latitude":33.624483,
     "geom:longitude":-7.383386,
@@ -127,12 +127,13 @@
         "wd:id":"Q1149096",
         "wk:page":"Mohammedia"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051531,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fd3e552f0dc43e3a3834d2431e85155f",
+    "wof:geomhash":"95f12ddc6478ae3de45ada57091ff94e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":890424147,
-    "wof:lastmodified":1690938993,
+    "wof:lastmodified":1695886565,
     "wof:name":"Mohammedia",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/424/149/890424149.geojson
+++ b/data/890/424/149/890424149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.970086,
-    "geom:area_square_m":21023867018.925049,
+    "geom:area_square_m":21023866037.492455,
     "geom:bbox":"-6.97661,29.482767,-5.039185,31.150141",
     "geom:latitude":30.339028,
     "geom:longitude":-5.926873,
@@ -141,12 +141,13 @@
         "wd:id":"Q2265471",
         "wk:page":"Zagora"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051532,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"25cfb5c5882a6d6d9e4ff3f2d7213970",
+    "wof:geomhash":"e0b580eb953a1e3a01b3295891a3829f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":890424149,
-    "wof:lastmodified":1690938993,
+    "wof:lastmodified":1695886565,
     "wof:name":"Zagora",
     "wof:parent_id":1796661363,
     "wof:placetype":"county",

--- a/data/890/424/151/890424151.geojson
+++ b/data/890/424/151/890424151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022715,
-    "geom:area_square_m":234236433.85828,
+    "geom:area_square_m":234236366.546247,
     "geom:bbox":"-7.588988,33.412003,-7.367263,33.578208",
     "geom:latitude":33.492719,
     "geom:longitude":-7.481182,
@@ -136,12 +136,13 @@
         "wd:id":"Q1957680",
         "wk:page":"Mediouna"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051532,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8d33686bbb0ccc21a6a48d87a816ec7a",
+    "wof:geomhash":"bbd07ac3659ae412d11d68f4f071487c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":890424151,
-    "wof:lastmodified":1690938985,
+    "wof:lastmodified":1695886566,
     "wof:name":"Mediouna",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/427/533/890427533.geojson
+++ b/data/890/427/533/890427533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.336749,
-    "geom:area_square_m":3428094417.252743,
+    "geom:area_square_m":3428094100.511529,
     "geom:bbox":"-6.733552,34.102395,-5.777312,35.013721",
     "geom:latitude":34.585051,
     "geom:longitude":-6.264118,
@@ -240,12 +240,13 @@
         "wd:id":"Q990115",
         "wk:page":"Khenifra"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051701,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d16adaafc00d29e48f498d2bf39fe216",
+    "wof:geomhash":"19923965818f69e0918815403537a15f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -255,7 +256,7 @@
         }
     ],
     "wof:id":890427533,
-    "wof:lastmodified":1690939097,
+    "wof:lastmodified":1695886566,
     "wof:name":"Kenitra",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/890/428/801/890428801.geojson
+++ b/data/890/428/801/890428801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.477332,
-    "geom:area_square_m":5130618123.394907,
+    "geom:area_square_m":5130618900.804073,
     "geom:bbox":"-10.012283,29.268084,-8.601132,29.935323",
     "geom:latitude":29.627285,
     "geom:longitude":-9.343692,
@@ -151,12 +151,13 @@
         "wd:id":"Q2339589",
         "wk:page":"Tiznit"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051773,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"11e27d1c583279c6f4efd947337426a0",
+    "wof:geomhash":"510d9d240fa1511914e3952bb84ce78a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":890428801,
-    "wof:lastmodified":1690939047,
+    "wof:lastmodified":1695886566,
     "wof:name":"Tiznit",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/890/429/091/890429091.geojson
+++ b/data/890/429/091/890429091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307247,
-    "geom:area_square_m":3132059752.426892,
+    "geom:area_square_m":3132059686.817731,
     "geom:bbox":"-6.311797,34.110235,-5.319512,34.848225",
     "geom:latitude":34.471287,
     "geom:longitude":-5.742593,
@@ -147,12 +147,13 @@
         "wd:id":"Q1969542",
         "wk:page":"Sidi Kacem"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051792,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7bc6e2d60cb718de7130c1be5b097149",
+    "wof:geomhash":"49143743bc59a72cac1697e5d9441769",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":890429091,
-    "wof:lastmodified":1690939068,
+    "wof:lastmodified":1695886566,
     "wof:name":"Sidi Kacem",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/890/429/093/890429093.geojson
+++ b/data/890/429/093/890429093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025956,
-    "geom:area_square_m":276996036.031359,
+    "geom:area_square_m":276996302.162678,
     "geom:bbox":"-9.622111,30.265507,-9.280097,30.433543",
     "geom:latitude":30.338118,
     "geom:longitude":-9.454589,
@@ -146,12 +146,13 @@
         "qs_pg:id":91817,
         "wd:id":"Q1662264"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"35b82ee197f97c98ea025cc3e167e898",
+    "wof:geomhash":"4e48b995f797a012831537df124efae1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":890429093,
-    "wof:lastmodified":1690939070,
+    "wof:lastmodified":1695886566,
     "wof:name":"Inezgane-Ait Melloul",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/890/429/095/890429095.geojson
+++ b/data/890/429/095/890429095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.362159,
-    "geom:area_square_m":3741257223.775917,
+    "geom:area_square_m":3741257337.612614,
     "geom:bbox":"-5.660776,32.866669,-4.828952,33.842851",
     "geom:latitude":33.337373,
     "geom:longitude":-5.199161,
@@ -146,12 +146,13 @@
         "wd:id":"Q2301648",
         "wk:page":"Ifrane"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f10e8d18bda8a0aa0c3d15ec4669e57d",
+    "wof:geomhash":"a1e972b67f8d394e6b96437a0139e742",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":890429095,
-    "wof:lastmodified":1690939070,
+    "wof:lastmodified":1695886566,
     "wof:name":"Ifrane",
     "wof:parent_id":1796661365,
     "wof:placetype":"county",

--- a/data/890/429/097/890429097.geojson
+++ b/data/890/429/097/890429097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.3509,
-    "geom:area_square_m":3556162233.272295,
+    "geom:area_square_m":3556162147.233598,
     "geom:bbox":"-4.790298,34.67082,-3.802969,35.264584",
     "geom:latitude":34.955982,
     "geom:longitude":-4.250898,
@@ -163,12 +163,13 @@
         "wd:id":"Q1969619",
         "wk:page":"Al Hoceima"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b2aeac54488afac7153e53f8ef528bb0",
+    "wof:geomhash":"6e78728cf25d6683d806233dd642eda6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":890429097,
-    "wof:lastmodified":1690939069,
+    "wof:lastmodified":1695886567,
     "wof:name":"Al Hoceima",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/890/429/099/890429099.geojson
+++ b/data/890/429/099/890429099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.227144,
-    "geom:area_square_m":2416423369.312168,
+    "geom:area_square_m":2416423261.272969,
     "geom:bbox":"-9.892083,30.351882,-9.229396,30.937056",
     "geom:latitude":30.64486,
     "geom:longitude":-9.538272,
@@ -144,12 +144,13 @@
         "qs_pg:id":91852,
         "wd:id":"Q389976"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"03afa31652d3c8d6539501543719e69d",
+    "wof:geomhash":"49d184e35434265068b6bc39f351b762",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":890429099,
-    "wof:lastmodified":1690939069,
+    "wof:lastmodified":1695886567,
     "wof:name":"Agadir Ida-Outanane",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/890/429/101/890429101.geojson
+++ b/data/890/429/101/890429101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106361,
-    "geom:area_square_m":1093403541.978508,
+    "geom:area_square_m":1093402890.916696,
     "geom:bbox":"-7.12668,33.543928,-6.719849,33.968786",
     "geom:latitude":33.759607,
     "geom:longitude":-6.893024,
@@ -129,12 +129,13 @@
         "qs_pg:id":91855,
         "wd:id":"Q737483"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469051793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1a20e676cceac9b860e6d271861c74f8",
+    "wof:geomhash":"c0fc84036ee3c61ac59b8e264ee5f948",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":890429101,
-    "wof:lastmodified":1690939069,
+    "wof:lastmodified":1695886567,
     "wof:name":"Skhirate-Temara",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/890/436/419/890436419.geojson
+++ b/data/890/436/419/890436419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.375849,
-    "geom:area_square_m":14224646181.594334,
+    "geom:area_square_m":14224646121.005545,
     "geom:bbox":"-5.021783,32.600802,-2.900746,33.906517",
     "geom:latitude":33.266251,
     "geom:longitude":-3.975595,
@@ -139,12 +139,13 @@
         "wd:id":"Q895063",
         "wk:page":"Boulemane"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052111,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d8a859c3daf36ca0326b3753812e35e",
+    "wof:geomhash":"8963ba55e1320276798ec8ea120b2f97",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":890436419,
-    "wof:lastmodified":1690939028,
+    "wof:lastmodified":1695886567,
     "wof:name":"Boulemane",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/436/421/890436421.geojson
+++ b/data/890/436/421/890436421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.243983,
-    "geom:area_square_m":2516264606.856563,
+    "geom:area_square_m":2516264520.830671,
     "geom:bbox":"-7.380489,33.196071,-6.7592,33.836537",
     "geom:latitude":33.481763,
     "geom:longitude":-7.085782,
@@ -138,12 +138,13 @@
         "wd:id":"Q15198365",
         "wk:page":"Benslimane"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052111,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9e88bf6acc4d0e619341ef5e4d7e4cf6",
+    "wof:geomhash":"7d68f014125bc57525d1d0e3b571138b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":890436421,
-    "wof:lastmodified":1690939028,
+    "wof:lastmodified":1695886567,
     "wof:name":"Benslimane",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/436/791/890436791.geojson
+++ b/data/890/436/791/890436791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.597424,
-    "geom:area_square_m":6102318571.426939,
+    "geom:area_square_m":6102318605.403577,
     "geom:bbox":"-4.589679,33.680398,-3.588295,34.88634",
     "geom:latitude":34.302798,
     "geom:longitude":-4.088731,
@@ -141,12 +141,13 @@
         "wd:id":"Q1819589",
         "wk:page":"Taza"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052126,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a131a365d527390ab6c82096164efef8",
+    "wof:geomhash":"bb55284e74c3d4d352e9c7101e4e24b5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":890436791,
-    "wof:lastmodified":1690939025,
+    "wof:lastmodified":1695886567,
     "wof:name":"Taza",
     "wof:parent_id":1796661365,
     "wof:placetype":"county",

--- a/data/890/437/999/890437999.geojson
+++ b/data/890/437/999/890437999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01163,
-    "geom:area_square_m":119267516.940301,
+    "geom:area_square_m":119267516.940304,
     "geom:bbox":"-6.917492,33.898345,-6.764286,34.035389",
     "geom:latitude":33.968387,
     "geom:longitude":-6.837896,
@@ -154,6 +154,7 @@
         "wd:id":"Q966104",
         "wk:page":"Rabat"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         890444507
     ],
@@ -162,7 +163,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b70597f298b3e8eaafe1cf4fe8b826a0",
+    "wof:geomhash":"912a77819bde8ba42821f216fdb39808",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":890437999,
-    "wof:lastmodified":1690939012,
+    "wof:lastmodified":1695886568,
     "wof:name":"Rabat",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/890/440/847/890440847.geojson
+++ b/data/890/440/847/890440847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.672591,
-    "geom:area_square_m":7105656940.665007,
+    "geom:area_square_m":7105657160.798571,
     "geom:bbox":"-9.319473,30.811277,-8.259195,31.77834",
     "geom:latitude":31.307732,
     "geom:longitude":-8.801046,
@@ -141,12 +141,13 @@
         "wd:id":"Q1072085",
         "wk:page":"Chichaoua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052299,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"943826f5b05053ccb54eba8850214644",
+    "wof:geomhash":"ccce097a97049b8dd3b84df3f8def442",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":890440847,
-    "wof:lastmodified":1690938960,
+    "wof:lastmodified":1695886568,
     "wof:name":"Chichaoua",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/890/440/849/890440849.geojson
+++ b/data/890/440/849/890440849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.336174,
-    "geom:area_square_m":3455581125.307755,
+    "geom:area_square_m":3455580875.703001,
     "geom:bbox":"-5.159993,33.510204,-4.096026,34.084025",
     "geom:latitude":33.767658,
     "geom:longitude":-4.637743,
@@ -137,12 +137,13 @@
         "wd:id":"Q1969535",
         "wk:page":"Sefrou"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052299,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f89058f67b3c6dd4cc72926e379c32cd",
+    "wof:geomhash":"02ecd2974e5fe7f17a2c7353cdc0fd1c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":890440849,
-    "wof:lastmodified":1690938959,
+    "wof:lastmodified":1695886568,
     "wof:name":"Sefrou",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/442/529/890442529.geojson
+++ b/data/890/442/529/890442529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071877,
-    "geom:area_square_m":721287683.919612,
+    "geom:area_square_m":721287734.955536,
     "geom:bbox":"-5.766449,35.590161,-5.379718,35.91711",
     "geom:latitude":35.75158,
     "geom:longitude":-5.581784,
@@ -136,12 +136,13 @@
         "qs_pg:id":630187,
         "wd:id":"Q2013946"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052366,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d627aee1d450a125497cbcda4232f999",
+    "wof:geomhash":"100facef6100dc4301fda1518571c115",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":890442529,
-    "wof:lastmodified":1690939098,
+    "wof:lastmodified":1695886568,
     "wof:name":"Fahs-Anjra",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/890/442/533/890442533.geojson
+++ b/data/890/442/533/890442533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022065,
-    "geom:area_square_m":227329344.436717,
+    "geom:area_square_m":227329275.550629,
     "geom:bbox":"-7.738187,33.494823,-7.459445,33.647306",
     "geom:latitude":33.569767,
     "geom:longitude":-7.600393,
@@ -473,12 +473,13 @@
         "wd:id":"Q7903",
         "wk:page":"Casablanca"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052366,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6eda0e905d4f0f1b382e52fae3fa799e",
+    "wof:geomhash":"8b94b1475ac7cea0b67c010d2ad4d85b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -488,7 +489,7 @@
         }
     ],
     "wof:id":890442533,
-    "wof:lastmodified":1690939098,
+    "wof:lastmodified":1695886568,
     "wof:name":"Casablanca",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/445/395/890445395.geojson
+++ b/data/890/445/395/890445395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.488271,
-    "geom:area_square_m":15863382926.142065,
+    "geom:area_square_m":15863382655.523617,
     "geom:bbox":"-9.328486,29.71871,-7.520316,31.159308",
     "geom:latitude":30.455633,
     "geom:longitude":-8.424071,
@@ -143,12 +143,13 @@
         "wd:id":"Q2092298",
         "wk:page":"Taroudant"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052508,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ed87cb49b2ee6cbbc32a0cf746c8339d",
+    "wof:geomhash":"6ca8413ccd187919a71f696e43e9a872",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":890445395,
-    "wof:lastmodified":1690939103,
+    "wof:lastmodified":1695886568,
     "wof:name":"Taroudant",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/890/445/397/890445397.geojson
+++ b/data/890/445/397/890445397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.395186,
-    "geom:area_square_m":4132610907.370044,
+    "geom:area_square_m":4132611143.115175,
     "geom:bbox":"-9.463471,31.777829,-8.548417,32.73038",
     "geom:latitude":32.251104,
     "geom:longitude":-9.023901,
@@ -145,12 +145,13 @@
         "wd:id":"Q637778",
         "wk:page":"Safi"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052508,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0dfe72e29d7c82e274f3c6c6150320f7",
+    "wof:geomhash":"fc0c05b43048b2465d80a69418d4ba9d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":890445397,
-    "wof:lastmodified":1690939101,
+    "wof:lastmodified":1695886568,
     "wof:name":"Safi",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/890/445/399/890445399.geojson
+++ b/data/890/445/399/890445399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.379463,
-    "geom:area_square_m":3933215990.428576,
+    "geom:area_square_m":3933216149.68334,
     "geom:bbox":"-8.952363,32.694481,-7.956375,33.463722",
     "geom:latitude":33.043022,
     "geom:longitude":-8.38969,
@@ -150,12 +150,13 @@
         "wd:id":"Q599606",
         "wk:page":"El Jadida"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052508,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bcdf632a1eea9f5cbe462a6333a1c696",
+    "wof:geomhash":"4b1528b1f5112aa429f7e58906d136ef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":890445399,
-    "wof:lastmodified":1690939100,
+    "wof:lastmodified":1695886569,
     "wof:name":"El Jadida",
     "wof:parent_id":1796661359,
     "wof:placetype":"county",

--- a/data/890/452/779/890452779.geojson
+++ b/data/890/452/779/890452779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.427469,
-    "geom:area_square_m":4459800892.983466,
+    "geom:area_square_m":4459800300.124376,
     "geom:bbox":"-6.651886,32.128721,-5.449247,32.777075",
     "geom:latitude":32.4623,
     "geom:longitude":-6.033532,
@@ -153,12 +153,13 @@
         "wd:id":"Q1019461",
         "wk:page":"Beni Mellal"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052829,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e34c01633cff0e2c811ae4c0e80fd02",
+    "wof:geomhash":"e9806031da5334f6096326eef8e753e8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":890452779,
-    "wof:lastmodified":1690939019,
+    "wof:lastmodified":1695886569,
     "wof:name":"Beni Mellal",
     "wof:parent_id":1796661357,
     "wof:placetype":"county",

--- a/data/890/453/851/890453851.geojson
+++ b/data/890/453/851/890453851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.46719,
-    "geom:area_square_m":26533279369.691338,
+    "geom:area_square_m":26533278707.294048,
     "geom:bbox":"-9.245979,28.323762,-6.355381,30.460874",
     "geom:latitude":29.569192,
     "geom:longitude":-7.841275,
@@ -138,12 +138,13 @@
         "wd:id":"Q546437",
         "wk:page":"Tata"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052875,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fea178d9ecfb0cdb42b789b31499bc75",
+    "wof:geomhash":"edbd1f1e35906c420dd58a3fcaabebd1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":890453851,
-    "wof:lastmodified":1690939043,
+    "wof:lastmodified":1695886569,
     "wof:name":"Tata",
     "wof:parent_id":1796661379,
     "wof:placetype":"county",

--- a/data/890/453/883/890453883.geojson
+++ b/data/890/453/883/890453883.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.384845,
-    "geom:area_square_m":3894114014.519498,
+    "geom:area_square_m":3894113968.895986,
     "geom:bbox":"-5.5459,34.764978,-4.471219,35.434475",
     "geom:latitude":35.083158,
     "geom:longitude":-5.004924,
@@ -147,12 +147,13 @@
         "wd:id":"Q2354922",
         "wk:page":"Chefchaouen Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052877,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3767c29425330ee9e384656c2928378d",
+    "wof:geomhash":"6d126d6b89b76cd9a2409675e022194b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":890453883,
-    "wof:lastmodified":1690939045,
+    "wof:lastmodified":1695886569,
     "wof:name":"Chefchaouen",
     "wof:parent_id":1796661381,
     "wof:placetype":"county",

--- a/data/890/453/895/890453895.geojson
+++ b/data/890/453/895/890453895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.18082,
-    "geom:area_square_m":1838824955.399351,
+    "geom:area_square_m":1838825363.432364,
     "geom:bbox":"-2.348586,34.401701,-1.739081,34.935949",
     "geom:latitude":34.672203,
     "geom:longitude":-2.075413,
@@ -145,12 +145,13 @@
         "qs_pg:id":575034,
         "wd:id":"Q1734717"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052877,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"89dc3753001d5b02adae77b36b962720",
+    "wof:geomhash":"76f22aa2ce3c1737c3b0ed1e43567d36",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":890453895,
-    "wof:lastmodified":1690939043,
+    "wof:lastmodified":1695886569,
     "wof:name":"Oujda-Angad",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",

--- a/data/890/453/897/890453897.geojson
+++ b/data/890/453/897/890453897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.750436,
-    "geom:area_square_m":7721658668.979414,
+    "geom:area_square_m":7721658967.30188,
     "geom:bbox":"-6.828635,33.151227,-5.71683,34.168409",
     "geom:latitude":33.68006,
     "geom:longitude":-6.267832,
@@ -144,12 +144,13 @@
         "wd:id":"Q1740735",
         "wk:page":"Khemisset"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052877,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fbb733fdc70f3e39ffebfe98ca6e2e2a",
+    "wof:geomhash":"7faae85b3aa3daf534962315fdc7d9bc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":890453897,
-    "wof:lastmodified":1690939045,
+    "wof:lastmodified":1695886570,
     "wof:name":"Khemisset",
     "wof:parent_id":1796661377,
     "wof:placetype":"county",

--- a/data/890/453/939/890453939.geojson
+++ b/data/890/453/939/890453939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.624123,
-    "geom:area_square_m":6589290343.708525,
+    "geom:area_square_m":6589290370.669579,
     "geom:bbox":"-9.846278,30.787521,-8.971123,31.934962",
     "geom:latitude":31.368749,
     "geom:longitude":-9.452458,
@@ -161,12 +161,13 @@
         "wd:id":"Q1368543",
         "wk:page":"Essaouira"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052878,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e8fa5589c6b7a1af5d20cb1bf441bd11",
+    "wof:geomhash":"1bae2a867c81931283bdeb7667c23fb3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":890453939,
-    "wof:lastmodified":1690939043,
+    "wof:lastmodified":1695886570,
     "wof:name":"Essaouira",
     "wof:parent_id":1796661373,
     "wof:placetype":"county",

--- a/data/890/454/333/890454333.geojson
+++ b/data/890/454/333/890454333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030615,
-    "geom:area_square_m":313876220.835411,
+    "geom:area_square_m":313876163.464794,
     "geom:bbox":"-5.07181,33.854685,-4.790677,34.075977",
     "geom:latitude":33.989765,
     "geom:longitude":-4.939601,
@@ -217,12 +217,13 @@
         "wd:id":"Q1479285",
         "wk:page":"Fez, Morocco"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052896,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1aaf730fb2c09edade461ce760d5bd03",
+    "wof:geomhash":"316962bb1ec5d41b6b5c3a1d88781ee6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -238,7 +239,7 @@
         }
     ],
     "wof:id":890454333,
-    "wof:lastmodified":1690939038,
+    "wof:lastmodified":1695886570,
     "wof:name":"Fes",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/271/890455271.geojson
+++ b/data/890/455/271/890455271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.310858,
-    "geom:area_square_m":3149027907.601815,
+    "geom:area_square_m":3149028014.025178,
     "geom:bbox":"-3.269239,34.662194,-2.347538,35.441971",
     "geom:latitude":34.990408,
     "geom:longitude":-2.920543,
@@ -159,12 +159,13 @@
         "wd:id":"Q367864",
         "wk:page":"Nador"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MA",
     "wof:created":1469052941,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"77e2bbaea9abe83e6fca3fc1d2b21627",
+    "wof:geomhash":"6e927fea41c7224d1bd0d58d4e43a4ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":890455271,
-    "wof:lastmodified":1690939025,
+    "wof:lastmodified":1695886570,
     "wof:name":"Nador",
     "wof:parent_id":1796661375,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.